### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to icon-only links

### DIFF
--- a/lib/lang_web/components/footer.ex
+++ b/lib/lang_web/components/footer.ex
@@ -58,12 +58,22 @@ defmodule LangWeb.Components.Footer do
               Universal Text Intelligence Platform. Transform any text into actionable insights.
             </p>
             <div class="flex gap-4">
-              <a href="https://github.com/lang" class="text-gray-500 hover:text-gray-300">
+              <a
+                href="https://github.com/lang"
+                class="text-gray-500 hover:text-gray-300"
+                aria-label="GitHub"
+                title="GitHub"
+              >
                 <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
                 </svg>
               </a>
-              <a href="https://twitter.com/lang" class="text-gray-500 hover:text-gray-300">
+              <a
+                href="https://twitter.com/lang"
+                class="text-gray-500 hover:text-gray-300"
+                aria-label="Twitter"
+                title="Twitter"
+              >
                 <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z" />
                 </svg>

--- a/lib/lang_web/components/layouts/root.html.heex
+++ b/lib/lang_web/components/layouts/root.html.heex
@@ -52,7 +52,7 @@
   <body class="min-h-screen bg-gray-950 text-gray-100">
     <header class="navbar px-4 sm:px-6 lg:px-8 bg-gray-900/80 backdrop-blur-sm border-b border-gray-800">
       <div class="flex-1">
-        <a href="/" class="flex items-center">
+        <a href="/" class="flex items-center" aria-label="Home" title="Home">
           <svg class="w-8 h-8 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               stroke-linecap="round"


### PR DESCRIPTION
🎨 Palette UX Enhancement:
Added `aria-label` and `title` attributes to the home logo link in `root.html.heex` and the GitHub/Twitter social media links in `footer.ex`. These were previously icon-only links lacking accessible names.

💡 What:
Added accessible names (`aria-label`) and hover tooltips (`title`) to the main navigation logo and footer social links.

🎯 Why:
To ensure screen reader users can understand the purpose and destination of these links, and to provide helpful tooltips for sighted users navigating via mouse.

♿ Accessibility:
Fixes missing ARIA labels on interactive `<a href>` elements that only contain `<svg>` children, addressing a common WCAG accessibility failure.

---
*PR created automatically by Jules for task [6557832627907639465](https://jules.google.com/task/6557832627907639465) started by @locsic*