### PR TITLE
🔒 Fix Denial of Service vulnerability via String.to_atom on untrusted Oban job arguments

### DIFF
--- a/lib/lang/workers/billing_aggregate_usage_worker.ex
+++ b/lib/lang/workers/billing_aggregate_usage_worker.ex
@@ -7,7 +7,7 @@ defmodule Lang.Workers.BillingAggregateUsageWorker do
   @impl true
   def perform(%Oban.Job{args: args}) do
     org_id = args["organization_id"]
-    gran = (args["granularity"] || "hour") |> to_string() |> String.to_atom()
+    gran = (args["granularity"] || "hour") |> to_string() |> String.to_existing_atom()
     now = DateTime.utc_now()
     {period_start, period_end} = period_bounds(now, gran)
 
@@ -48,6 +48,10 @@ defmodule Lang.Workers.BillingAggregateUsageWorker do
 
     {:ok, %{period_start: period_start, period_end: period_end, granularity: gran}}
   rescue
+    e in ArgumentError ->
+      Logger.error("Security warning: Invalid granularity provided for billing aggregation: #{inspect(args["granularity"])}")
+      {:error, e}
+
     e ->
       Logger.error("AggregateUsageWorker failed", error: Exception.message(e))
       :error

--- a/lib/lang/workers/cloud_environment.ex
+++ b/lib/lang/workers/cloud_environment.ex
@@ -12,7 +12,11 @@ defmodule Lang.Workers.CloudEnvironment do
   Main entry point for cloud environment tasks
   """
   def perform(%Oban.Job{args: %{"task" => task} = args}) do
-    execute_task(String.to_atom(task), args)
+    execute_task(String.to_existing_atom(task), args)
+  rescue
+    e in ArgumentError ->
+      Logger.error("Security warning: Invalid task provided for cloud environment: #{task}")
+      {:error, e}
   end
 
   def execute_task(:discover_resources, args) do

--- a/lib/lang/workers/filesystem_environment.ex
+++ b/lib/lang/workers/filesystem_environment.ex
@@ -12,7 +12,11 @@ defmodule Lang.Workers.FilesystemEnvironment do
   Main entry point for filesystem environment tasks
   """
   def perform(%Oban.Job{args: %{"task" => task} = args}) do
-    execute_task(String.to_atom(task), args)
+    execute_task(String.to_existing_atom(task), args)
+  rescue
+    e in ArgumentError ->
+      Logger.error("Security warning: Invalid task provided for filesystem environment: #{task}")
+      {:error, e}
   end
 
   def execute_task(:generate_spec, args) do

--- a/lib/lang/workers/lsp_comparison_worker.ex
+++ b/lib/lang/workers/lsp_comparison_worker.ex
@@ -37,7 +37,7 @@ defmodule Lang.Workers.LSPComparisonWorker do
 
     try do
       # Get scenario configuration
-      scenario = ScenarioDefinitions.get_scenario(String.to_atom(scenario_id))
+      scenario = ScenarioDefinitions.get_scenario(String.to_existing_atom(scenario_id))
 
       # Reconstruct agent variant
       variant = reconstruct_agent_variant(agent_variant)
@@ -78,6 +78,10 @@ defmodule Lang.Workers.LSPComparisonWorker do
 
       :ok
     rescue
+      e in ArgumentError ->
+        Logger.error("Security warning: Invalid scenario_id or agent_module provided for LSP comparison: #{scenario_id}/#{Map.get(agent_variant, "provider_module")}")
+        {:error, e}
+
       error ->
         completion_time = System.monotonic_time(:millisecond) - start_time
 
@@ -262,7 +266,7 @@ defmodule Lang.Workers.LSPComparisonWorker do
     {method, params} = convert_task_to_provider_request(task, context, lsp_enabled)
 
     # Execute via the agent variant
-    case apply(String.to_atom(agent_module), :handle_request, [method, params, []]) do
+    case apply(String.to_existing_atom(agent_module), :handle_request, [method, params, []]) do
       {:ok, result} ->
         %{
           status: :success,

--- a/lib/lang/workers/marketing_generator.ex
+++ b/lib/lang/workers/marketing_generator.ex
@@ -18,7 +18,7 @@ defmodule Lang.Workers.MarketingGenerator do
     start_time = System.monotonic_time(:millisecond)
 
     try do
-      result = generate_content(String.to_atom(env), String.to_atom(type), args)
+      result = generate_content(String.to_existing_atom(env), String.to_existing_atom(type), args)
       duration = System.monotonic_time(:millisecond) - start_time
 
       Logger.info("Generated #{type} for #{env} in #{duration}ms")
@@ -32,6 +32,10 @@ defmodule Lang.Workers.MarketingGenerator do
 
       :ok
     rescue
+      e in ArgumentError ->
+        Logger.error("Security warning: Invalid environment or type provided for marketing: #{env}/#{type}")
+        {:error, e}
+
       error ->
         Logger.error("Failed to generate #{type} for #{env}: #{inspect(error)}")
         {:error, error}

--- a/lib/lang/workers/orchestration_monitor.ex
+++ b/lib/lang/workers/orchestration_monitor.ex
@@ -222,7 +222,7 @@ defmodule Lang.Workers.OrchestrationMonitor do
     # Create a new job with the same parameters
     new_args = Map.put(job.args, "restarted_from", job.id)
 
-    worker_module = String.to_atom("Elixir.#{job.worker}")
+    worker_module = String.to_existing_atom("Elixir.#{job.worker}")
 
     new_args
     |> worker_module.new()

--- a/lib/lang/workers/orchestrator_worker.ex
+++ b/lib/lang/workers/orchestrator_worker.ex
@@ -20,7 +20,7 @@ defmodule Lang.Workers.OrchestratorWorker do
     start_time = System.monotonic_time(:millisecond)
 
     try do
-      result = execute_task(String.to_atom(env), String.to_atom(task), args)
+      result = execute_task(String.to_existing_atom(env), String.to_existing_atom(task), args)
 
       duration = System.monotonic_time(:millisecond) - start_time
 
@@ -41,6 +41,11 @@ defmodule Lang.Workers.OrchestratorWorker do
 
       :ok
     rescue
+      e in ArgumentError ->
+        Logger.error("Security warning: Invalid environment or task provided: #{env}/#{task}")
+        Master.notify_job_failed(args["job_id"], e)
+        {:error, e}
+
       error ->
         Logger.error("Failed to execute #{task} for #{env}: #{inspect(error)}")
         Master.notify_job_failed(args["job_id"], error)
@@ -997,7 +1002,7 @@ defmodule Lang.Workers.OrchestratorWorker do
           task: task,
           triggered_by: completed_task
         }
-        |> __MODULE__.new(queue: queue_for_env(String.to_atom(env)))
+        |> __MODULE__.new(queue: queue_for_env(String.to_existing_atom(env)))
         |> Oban.insert!()
       end
     end)
@@ -1005,7 +1010,7 @@ defmodule Lang.Workers.OrchestratorWorker do
 
   defp get_task_dependencies(env) do
     # Return task dependencies for the environment
-    case String.to_atom(env) do
+    case String.to_existing_atom(env) do
       :text ->
         %{
           implement_parsers: [:generate_spec],
@@ -1042,6 +1047,6 @@ defmodule Lang.Workers.OrchestratorWorker do
   end
 
   defp queue_for_env(env) when is_binary(env) do
-    queue_for_env(String.to_atom(env))
+    queue_for_env(String.to_existing_atom(env))
   end
 end

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -120,7 +120,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = String.to_existing_atom(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -136,6 +136,10 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
           {:error, reason}
       end
     rescue
+      e in ArgumentError ->
+        Logger.error("Security warning: Invalid period_type provided for user metrics: #{args["period_type"]}")
+        {:error, e}
+
       error ->
         Logger.error("Exception in user metrics update: #{inspect(error)}")
         {:error, :processing_exception}
@@ -143,7 +147,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = String.to_existing_atom(args["period_type"])
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -181,6 +185,10 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
           {:error, reason}
       end
     rescue
+      e in ArgumentError ->
+        Logger.error("Security warning: Invalid period_type provided for efficiency report: #{args["period_type"]}")
+        {:error, e}
+
       error ->
         Logger.error("Exception in efficiency report generation: #{inspect(error)}")
         {:error, :processing_exception}
@@ -189,7 +197,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = String.to_existing_atom(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")
@@ -213,6 +221,10 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
           {:error, reason}
       end
     rescue
+      e in ArgumentError ->
+        Logger.error("Security warning: Invalid period_type provided for organization aggregation: #{args["period_type"]}")
+        {:error, e}
+
       error ->
         Logger.error("Exception in organization aggregation: #{inspect(error)}")
         {:error, :processing_exception}

--- a/lib/lang/workers/sdk_generator.ex
+++ b/lib/lang/workers/sdk_generator.ex
@@ -8,11 +8,17 @@ defmodule Lang.Workers.SDKGenerator do
   @api_base "https://lang.nocsi.com/api"
 
   def perform(%Oban.Job{args: %{"environment" => env, "language" => lang}}) do
-    with {:ok, spec} <- load_openapi_spec(env),
-         {:ok, sdk_code} <- generate_sdk(spec, lang, env),
-         {:ok, _published} <- publish_sdk(sdk_code, lang, env) do
-      notify_sdk_ready(env, lang)
-      :ok
+    try do
+      with {:ok, spec} <- load_openapi_spec(env),
+           {:ok, sdk_code} <- generate_sdk(spec, lang, env),
+           {:ok, _published} <- publish_sdk(sdk_code, lang, env) do
+        notify_sdk_ready(env, lang)
+        :ok
+      end
+    rescue
+      e in ArgumentError ->
+        Logger.error("Security warning: Invalid atom string provided in SDK generation for #{env}/#{lang}")
+        {:error, e}
     end
   end
 
@@ -528,7 +534,7 @@ defmodule Lang.Workers.SDKGenerator do
           #{Map.get(operation, "summary", "API method")}
           \"\"\"
           def #{method_name}(client, data, opts \\\\ []) do
-            case request(client, :#{String.to_atom(method)}, "#{path}", data, opts) do
+            case request(client, :#{String.to_existing_atom(method)}, "#{path}", data, opts) do
               {:ok, %{status: 200, body: body}} -> {:ok, body}
               {:ok, %{status: status, body: body}} -> {:error, {status, body}}
               error -> error

--- a/lib/lang/workers/swarm_export_worker.ex
+++ b/lib/lang/workers/swarm_export_worker.ex
@@ -15,17 +15,23 @@ defmodule Lang.Workers.SwarmExportWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"kind" => kind, "format" => format, "export_id" => export_id} = args}) do
-    case {kind, format} do
-      {"swarms", "ndjson"} -> export_swarms_ndjson(args)
-      {"agents", "ndjson"} -> export_agents_ndjson(args)
-      other ->
-        Logger.warning("Unsupported export request", request: other)
-        :discard
-    end
+    try do
+      case {kind, format} do
+        {"swarms", "ndjson"} -> export_swarms_ndjson(args)
+        {"agents", "ndjson"} -> export_agents_ndjson(args)
+        other ->
+          Logger.warning("Unsupported export request", request: other)
+          :discard
+      end
 
-    # Notify listeners
-    PubSub.broadcast(Lang.PubSub, "exports:#{export_id}", {:export_ready, export_id})
-    :ok
+      # Notify listeners
+      PubSub.broadcast(Lang.PubSub, "exports:#{export_id}", {:export_ready, export_id})
+      :ok
+    rescue
+      e in ArgumentError ->
+        Logger.error("Security warning: Invalid filter state provided in swarm export: #{export_id}")
+        {:error, e}
+    end
   end
 
   defp export_swarms_ndjson(%{"export_id" => id, "filters" => filters}) do
@@ -109,7 +115,7 @@ defmodule Lang.Workers.SwarmExportWorker do
     q =
       case String.trim(to_string(st)) do
         "" -> q
-        state -> filter(q, state == ^String.to_atom(state))
+        state -> filter(q, state == ^String.to_existing_atom(state))
       end
 
     case Float.parse(to_string(mt)) do

--- a/lib/lang/workers/systems_environment.ex
+++ b/lib/lang/workers/systems_environment.ex
@@ -12,7 +12,11 @@ defmodule Lang.Workers.SystemsEnvironment do
   Main entry point for systems environment tasks
   """
   def perform(%Oban.Job{args: %{"task" => task} = args}) do
-    execute_task(String.to_atom(task), args)
+    execute_task(String.to_existing_atom(task), args)
+  rescue
+    e in ArgumentError ->
+      Logger.error("Security warning: Invalid task provided for systems environment: #{task}")
+      {:error, e}
   end
 
   def execute_task(:analyze_system_topology, args) do

--- a/lib/lang/workers/text_environment.ex
+++ b/lib/lang/workers/text_environment.ex
@@ -17,7 +17,11 @@ defmodule Lang.Workers.TextEnvironment do
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"task" => task} = args}) do
-    execute_task(String.to_atom(task), args)
+    execute_task(String.to_existing_atom(task), args)
+  rescue
+    e in ArgumentError ->
+      Logger.error("Security warning: Invalid task provided for text environment: #{task}")
+      {:error, e}
   end
 
   def execute_task(:generate_spec, args) do

--- a/test/lang/workers/orchestrator_worker_test.exs
+++ b/test/lang/workers/orchestrator_worker_test.exs
@@ -1,0 +1,69 @@
+defmodule Lang.Workers.OrchestratorWorkerTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+  alias Lang.Workers.OrchestratorWorker
+  alias Oban.Job
+
+  describe "perform/1 security" do
+    test "successfully converts existing environment and task strings" do
+      # Ensure these atoms exist in the VM
+      _ = :text
+      _ = :generate_spec
+
+      args = %{
+        "environment" => "text",
+        "task" => "generate_spec",
+        "job_id" => "test-job-id"
+      }
+
+      # We don't necessarily need the whole job to succeed (it might fail on Master.notify or File.write)
+      # but it should NOT fail with the security ArgumentError rescue block if atoms exist.
+
+      log = capture_log(fn ->
+        OrchestratorWorker.perform(%Job{args: args})
+      end)
+
+      # If it reached the stage where it tries to call Master, it passed atom conversion.
+      # We check that our specific security warning is NOT in the log.
+      refute log =~ "Security warning: Invalid environment or task provided"
+    end
+
+    test "handles non-existent environment string with security warning" do
+      # Use a random string that definitely isn't an atom
+      invalid_env = "env_#{[:erlang.system_time(), :erlang.unique_integer()] |> Enum.join("_")}"
+
+      args = %{
+        "environment" => invalid_env,
+        "task" => "generate_spec",
+        "job_id" => "test-job-id"
+      }
+
+      log = capture_log(fn ->
+        result = OrchestratorWorker.perform(%Job{args: args})
+        assert {:error, %ArgumentError{}} = result
+      end)
+
+      assert log =~ "Security warning: Invalid environment or task provided"
+      assert log =~ invalid_env
+    end
+
+    test "handles non-existent task string with security warning" do
+      # Use a random string that definitely isn't an atom
+      invalid_task = "task_#{[:erlang.system_time(), :erlang.unique_integer()] |> Enum.join("_")}"
+
+      args = %{
+        "environment" => "text",
+        "task" => invalid_task,
+        "job_id" => "test-job-id"
+      }
+
+      log = capture_log(fn ->
+        result = OrchestratorWorker.perform(%Job{args: args})
+        assert {:error, %ArgumentError{}} = result
+      end)
+
+      assert log =~ "Security warning: Invalid environment or task provided"
+      assert log =~ invalid_task
+    end
+  end
+end


### PR DESCRIPTION
🎯 **What:** This PR fixes a Denial of Service (DoS) vulnerability where untrusted strings from Oban job arguments were being converted into atoms using `String.to_atom/1`.

⚠️ **Risk:** Atoms are not garbage collected in the Erlang VM. By sending a large number of unique strings in job arguments, an attacker could exhaust the system's atom table, causing the VM to crash and creating a Denial of Service.

🛡️ **Solution:**
1. Replaced all occurrences of `String.to_atom/1` with `String.to_existing_atom/1` in workers processing dynamic arguments.
2. Implemented error handling (`rescue ArgumentError`) to catch cases where a non-existent atom is provided.
3. Added logging for security warnings to aid in auditing and threat detection.
4. Added a new test suite to verify that valid atoms still work while invalid ones are handled securely.

Verified across core orchestration workers and secondary metrics/generator workers.

---
*PR created automatically by Jules for task [6456165250898406366](https://jules.google.com/task/6456165250898406366) started by @locsic*