### PR TITLE
🧹 remove commented out code in TreeParser docs

### DIFF
--- a/lib/lang/native/tree_parser.ex
+++ b/lib/lang/native/tree_parser.ex
@@ -551,18 +551,6 @@ defmodule Lang.Native.TreeParser do
   ## Examples
 
       {:ok, stats_json} = Lang.Native.TreeParser.get_ast_statistics(ast)
-      # stats = Jason.decode!(stats_json)
-
-      # IO.puts("Parsed source code and generated AST")
-      # IO.puts("Statistics available in JSON format")
-
-      # if stats["error_count"] > 0 do
-      #   IO.puts("Warning: Parse errors detected")
-      # end
-
-      # if length(stats["warnings"]) > 0 do
-      #   IO.puts("Warnings found")
-      # end
 
   ## Performance Monitoring
   Statistics help monitor parser performance:


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
  Removed a block of commented-out code from the `## Examples` section of the `get_ast_statistics/1` function's documentation in `lib/lang/native/tree_parser.ex`.

💡 **Why:** How this improves maintainability
  Commented-out code blocks in documentation can be confusing to readers and clutter the codebase. Removing them improves the overall readability and maintainability of the module.

✅ **Verification:** How you confirmed the change is safe
  Verified that the change is limited to the documentation (inside the `@doc` block) and does not modify any executable code. Attempted to run the full test suite and compilation, though network issues prevented the installation of the necessary toolchain (Elixir/Erlang) via `mise`. Given the documentation-only nature of the fix, it is inherently safe.

✨ **Result:** The improvement achieved
  The `get_ast_statistics/1` documentation is now cleaner and more focused on clear usage examples.

---
*PR created automatically by Jules for task [14745167440852015294](https://jules.google.com/task/14745167440852015294) started by @locsic*