### PR TITLE
🎨 Palette: Add disabled states to pagination buttons

### DIFF
--- a/lib/lang_web/live/swarm_show_live.ex
+++ b/lib/lang_web/live/swarm_show_live.ex
@@ -344,9 +344,9 @@ defmodule LangWeb.SwarmShowLive do
                     <option value="20" selected={@agents_paging.page_size == 20}>20</option>
                     <option value="50" selected={@agents_paging.page_size == 50}>50</option>
                   </select>
-                  <button phx-click="agents_set_page" phx-value-dir="prev" class="px-2 py-1 rounded border text-xs">Prev</button>
+                  <button phx-click="agents_set_page" phx-value-dir="prev" class="px-2 py-1 rounded border text-xs disabled:opacity-50" disabled={@agents_paging.page <= 1}>Prev</button>
                   <div class="text-xs">Page <%= @agents_paging.page %></div>
-                  <button phx-click="agents_set_page" phx-value-dir="next" class="px-2 py-1 rounded border text-xs">Next</button>
+                  <button phx-click="agents_set_page" phx-value-dir="next" class="px-2 py-1 rounded border text-xs disabled:opacity-50" disabled={length(@swarm.agents || []) < @agents_paging.page_size}>Next</button>
                   <button phx-click="export_agents_csv" class="px-2 py-1 rounded border text-xs">Export CSV</button>
                   <button phx-click="export_agents_json" class="px-2 py-1 rounded border text-xs">Export JSON</button>
                   <button phx-click="export_agents_ndjson_bg" class="px-2 py-1 rounded border text-xs">Export NDJSON (bg)</button>

--- a/lib/lang_web/live/swarms_live.ex
+++ b/lib/lang_web/live/swarms_live.ex
@@ -303,9 +303,9 @@ defmodule LangWeb.SwarmsLive do
         </div>
 
         <div class="flex items-center justify-between">
-          <button phx-click="set_page" phx-value-dir="prev" class="px-3 py-1 rounded border">Previous</button>
+          <button phx-click="set_page" phx-value-dir="prev" class="px-3 py-1 rounded border disabled:opacity-50" disabled={@paging.page <= 1}>Previous</button>
           <div class="text-sm">Page <%= @paging.page %></div>
-          <button phx-click="set_page" phx-value-dir="next" class="px-3 py-1 rounded border">Next</button>
+          <button phx-click="set_page" phx-value-dir="next" class="px-3 py-1 rounded border disabled:opacity-50" disabled={@empty? or length(current_swarms(%{assigns: assigns})) < @paging.page_size}>Next</button>
         </div>
       </div>
       <%= if @export_ready do %>


### PR DESCRIPTION
Added disabled states and visual feedback (opacity 50%) to the "Previous" and "Next" pagination buttons on the Swarms and Swarm details LiveView pages to improve micro-interaction UX when the user reaches the end of the lists.

---
*PR created automatically by Jules for task [12594407996172718757](https://jules.google.com/task/12594407996172718757) started by @locsic*