### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix atom table exhaustion vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-07 - [Atom Table Exhaustion in Workers]
+**Vulnerability:** Untrusted external arguments from Oban jobs (`period_type`) were parsed using `String.to_atom/1`, leading to potential atom table exhaustion and Denial of Service (DoS).
+**Learning:** Elixir atoms are not garbage collected. Using `String.to_atom/1` on arbitrary external input (like JSON arguments mapped to background workers) creates a vector to crash the VM by exceeding the atom limit.
+**Prevention:** Always use `String.to_existing_atom/1` for untrusted input conversions, properly catching the resulting `ArgumentError` and handling it defensively (e.g. logging and erroring out or falling back to safe defaults).

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -118,14 +118,26 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   # Private handlers
 
-  defp handle_user_metrics_update(args) do
-    user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
-    date = Date.from_iso8601!(args["date"])
-
-    Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
-
+  defp parse_period_type(nil), do: :daily
+  defp parse_period_type(str) when is_binary(str) do
     try do
+      String.to_existing_atom(str)
+    rescue
+      e in ArgumentError ->
+        Logger.warning("Security Warning: Attempted to convert unknown period_type to atom: #{inspect(str)}")
+        reraise e, __STACKTRACE__
+    end
+  end
+  defp parse_period_type(atom) when is_atom(atom), do: atom
+
+  defp handle_user_metrics_update(args) do
+    try do
+      user_id = args["user_id"]
+      period_type = parse_period_type(args["period_type"])
+      date = Date.from_iso8601!(args["date"])
+
+      Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
+
       case update_user_productivity_metrics(user_id, period_type, date) do
         {:ok, metrics} ->
           Logger.info("Successfully updated productivity metrics for user #{user_id}")
@@ -143,13 +155,13 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
-    date = Date.from_iso8601!(args["date"])
-    organization_id = args["organization_id"]
-
-    Logger.info("Generating efficiency report for #{period_type} on #{date}")
-
     try do
+      period_type = parse_period_type(args["period_type"])
+      date = Date.from_iso8601!(args["date"])
+      organization_id = args["organization_id"]
+
+      Logger.info("Generating efficiency report for #{period_type} on #{date}")
+
       opts = [date: date]
 
       opts =
@@ -188,13 +200,13 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_organization_aggregation(args) do
-    organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
-    date = Date.from_iso8601!(args["date"])
-
-    Logger.info("Aggregating organization metrics for #{organization_id}")
-
     try do
+      organization_id = args["organization_id"]
+      period_type = parse_period_type(args["period_type"])
+      date = Date.from_iso8601!(args["date"])
+
+      Logger.info("Aggregating organization metrics for #{organization_id}")
+
       case aggregate_organization_productivity(organization_id, period_type, date) do
         {:ok, results} ->
           Logger.info("Successfully aggregated organization metrics")


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix atom table exhaustion vulnerability in Oban workers

**🚨 Severity:** CRITICAL
**💡 Vulnerability:** Unsafe usage of `String.to_atom/1` on external user/job input inside `Lang.Workers.ProductivityMetricsWorker`.
**🎯 Impact:** Atom Table Exhaustion (Denial of Service). Atoms are not garbage collected. Repeatedly supplying unknown atoms via Oban job payloads forces the application to exceed the Erlang VM's atom limit, leading to an unrecoverable system crash.
**🔧 Fix:** Implemented a new defensive parser `parse_period_type/1` that strictly uses `String.to_existing_atom/1` while correctly handling defaults and catching `ArgumentError`s to log security alerts. Moved the input extraction code safely behind the existing `try...rescue` exception handling mechanisms.

Also recorded findings in `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [8607787606444072039](https://jules.google.com/task/8607787606444072039) started by @locsic*