### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix atom exhaustion vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Atom Exhaustion via Unsafe Input Conversion
+**Vulnerability:** Found `String.to_atom/1` used on untrusted background job arguments (e.g., Oban `args["period_type"]`) in background workers. Since atoms are not garbage collected, malicious or malformed input can quickly exhaust the atom table limit (typically ~1M atoms), leading to node crashes (Denial of Service).
+**Learning:** Background job arguments must be treated as untrusted user input, especially since they can be injected via unvalidated parameters.
+**Prevention:** Always use `String.to_existing_atom/1` instead of `String.to_atom/1` when converting dynamic or untrusted strings to atoms. Wrap the conversion in a `try...rescue ArgumentError` block to safely handle unknown inputs without crashing the process, logging a security warning, and falling back to a safe default.

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -118,9 +118,21 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   # Private handlers
 
+  defp safe_to_atom(nil, default), do: safe_to_atom(default, nil)
+  defp safe_to_atom(str, _default) when is_binary(str) do
+    try do
+      String.to_existing_atom(str)
+    rescue
+      ArgumentError ->
+        Logger.warning("Security Warning: Attempted to convert untrusted input to atom: #{inspect(str)}")
+        # Provide a safe fallback instead of crashing
+        :unknown
+    end
+  end
+
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_to_atom(args["period_type"], "daily")
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -143,7 +155,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = safe_to_atom(args["period_type"], "daily")
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -189,7 +201,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_to_atom(args["period_type"], "daily")
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsafe atom generation in background worker processing untrusted Oban job arguments via `String.to_atom/1`.
🎯 **Impact:** Maliciously crafted inputs could rapidly fill the BEAM atom table (which is never garbage collected), causing a Denial of Service node crash. 
🔧 **Fix:** Refactored the conversion to use `String.to_existing_atom/1` wrapped in a `try...rescue` block that gracefully falls back without crashing the system and emits a security log.
✅ **Verification:** Verified via `cat` / `grep` locally against the file and ran pre-commit suite. Also added a `.jules/sentinel.md` learnings entry.

---
*PR created automatically by Jules for task [1945785600359965078](https://jules.google.com/task/1945785600359965078) started by @locsic*