### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Atom Exhaustion DoS in Metrics Worker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-09 - Atom Exhaustion DoS via String.to_atom on Job Arguments
+**Vulnerability:** Found `String.to_atom/1` being used on unvalidated input (`period_type` argument from Oban job params) in `Lang.Workers.ProductivityMetricsWorker`. This allows attackers to exhaust the Erlang VM's atom table, causing a Denial of Service.
+**Learning:** Background workers (like Oban jobs) often process external or delayed data; treating their arguments as trusted and converting them to atoms directly is unsafe. The Erlang node limits the maximum number of atoms (typically 1_048_576), and they are not garbage collected.
+**Prevention:** Always use `String.to_existing_atom/1` combined with a `rescue` clause for `ArgumentError` when converting dynamic or external string inputs into atoms. Log the attempt for threat intelligence.

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -118,9 +118,20 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   # Private handlers
 
+  defp safe_to_atom(nil, default), do: default
+  defp safe_to_atom(str, default) when is_binary(str) do
+    try do
+      String.to_existing_atom(str)
+    rescue
+      ArgumentError ->
+        Logger.warning("Security Warning: Attempted atom exhaustion via untrusted input: #{inspect(str)}")
+        default
+    end
+  end
+
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_to_atom(args["period_type"], :daily)
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -143,7 +154,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = safe_to_atom(args["period_type"], :daily)
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -189,7 +200,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_to_atom(args["period_type"], :daily)
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unvalidated strings from job arguments were converted to atoms using `String.to_atom/1`, allowing malicious users to exhaust the Erlang VM's atom table.
🎯 **Impact:** Atom table exhaustion leads to immediate application crash and Denial of Service (DoS) across the entire Erlang node.
🔧 **Fix:** Replaced `String.to_atom/1` with a custom `safe_to_atom/1` function in `Lang.Workers.ProductivityMetricsWorker`. It utilizes `String.to_existing_atom/1` and cleanly defaults to `:daily` while logging a security warning if an `ArgumentError` occurs.
✅ **Verification:** Verified by code logic that `safe_to_atom/2` successfully returns the expected atom when one exists, and defaults cleanly to the provided default instead of crashing or generating a new atom when given an unknown string. A log warning will now be emitted to track the attack vector. Also recorded findings to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1828463013866617303](https://jules.google.com/task/1828463013866617303) started by @locsic*