### PR TITLE
Add proxy chain capture, replay and conformance reporting

### DIFF
--- a/lib/lang/proxy/chain_conformance.ex
+++ b/lib/lang/proxy/chain_conformance.ex
@@ -1,0 +1,214 @@
+defmodule Lang.Proxy.ChainConformance do
+  @moduledoc """
+  Replay/conformance utilities for proxy chain execution capture.
+
+  - Replays from captured `hop_start` route decisions.
+  - Supports optional per-hop remapping for resilience tests.
+  - Emits hop-by-hop conformance divergence reports.
+  """
+
+  alias Lang.Proxy.{Envelope, Pipeline, StreamCapture}
+
+  @spec replay(binary(), map(), map()) ::
+          {:ok, %{pipeline_id: binary(), route_mode: atom(), remapped: non_neg_integer(), result: any()}}
+          | {:error, term()}
+  def replay(source_pipeline_id, opts, assigns \\ %{}) when is_binary(source_pipeline_id) and is_map(opts) do
+    with {:ok, route} <- extract_route(source_pipeline_id),
+         {:ok, replay_route, remapped} <- maybe_remap_route(route, Map.get(opts, "route_remap", %{})) do
+      pipeline_id = Map.get(opts, "pipeline_id") || gen_id()
+      mode = mode(opts)
+
+      env = %Envelope{
+        v: 1,
+        service: :proxy,
+        method: "pipeline.run",
+        params: %{"route" => replay_route, "pipeline_id" => pipeline_id},
+        opts: %{},
+        meta: assigns,
+        stream?: false
+      }
+
+      case Pipeline.run(env, assigns) do
+        {:ok, result} ->
+          {:ok,
+           %{pipeline_id: pipeline_id, route_mode: mode, remapped: remapped, result: result}}
+
+        {:error, code, message, data} ->
+          {:error, %{code: code, message: message, data: data}}
+      end
+    end
+  end
+
+  def replay(_source_pipeline_id, _opts, _assigns), do: {:error, :invalid_source_pipeline_id}
+
+  @spec report(binary(), binary(), map()) :: {:ok, map()} | {:error, term()}
+  def report(baseline_pipeline_id, candidate_pipeline_id, opts \\ %{}) do
+    latency_tolerance_ms = Map.get(opts, "latency_tolerance_ms", 0)
+
+    with {:ok, baseline} <- build_hop_summary(baseline_pipeline_id),
+         {:ok, candidate} <- build_hop_summary(candidate_pipeline_id) do
+      max_hops = max(length(baseline), length(candidate))
+
+      rows =
+        if max_hops == 0 do
+          []
+        else
+          0..(max_hops - 1)
+          |> Enum.map(fn idx ->
+            b = Enum.at(baseline, idx)
+            c = Enum.at(candidate, idx)
+            compare_hop(idx, b, c, latency_tolerance_ms)
+          end)
+        end
+
+      divergences = Enum.filter(rows, &(&1.status == :diverged))
+
+      {:ok,
+       %{
+         baseline_pipeline_id: baseline_pipeline_id,
+         candidate_pipeline_id: candidate_pipeline_id,
+         total_hops: max_hops,
+         diverged_hops: length(divergences),
+         conformant: divergences == [],
+         hops: rows
+       }}
+    end
+  end
+
+  defp extract_route(pipeline_id) do
+    with {:ok, events} <- StreamCapture.list(pipeline_id) do
+      route =
+        events
+        |> Enum.reverse()
+        |> Enum.filter(&(Map.get(&1, "event") == "hop_start"))
+        |> Enum.map(&Map.get(&1, "payload", %{}))
+        |> Enum.map(&Map.get(&1, "route_decision", %{}))
+        |> Enum.map(&Map.take(&1, ["service", "method", "params", :service, :method, :params]))
+        |> Enum.map(&normalize_route_hop/1)
+        |> Enum.reject(&is_nil/1)
+
+      if route == [], do: {:error, :empty_route}, else: {:ok, route}
+    end
+  end
+
+  defp maybe_remap_route(route, remap) when map_size(remap) == 0, do: {:ok, route, 0}
+
+  defp maybe_remap_route(route, remap) do
+    {new_route, remapped} =
+      Enum.map_reduce(route, 0, fn hop, acc ->
+        method = hop["method"]
+
+        case Map.get(remap, method) do
+          nil -> {hop, acc}
+          new_method when is_binary(new_method) -> {Map.put(hop, "method", new_method), acc + 1}
+          replacement when is_map(replacement) -> {Map.merge(hop, stringify_keys(replacement)), acc + 1}
+          _ -> {hop, acc}
+        end
+      end)
+
+    {:ok, new_route, remapped}
+  end
+
+  defp build_hop_summary(pipeline_id) do
+    with {:ok, events} <- StreamCapture.list(pipeline_id) do
+      by_uid =
+        events
+        |> Enum.reverse()
+        |> Enum.reduce(%{}, fn ev, acc ->
+          hop = Map.get(ev, "hop") || %{}
+          uid = Map.get(hop, "uid") || Map.get(hop, :uid)
+          key = uid || "idx:" <> Integer.to_string(map_size(acc))
+          state = Map.get(acc, key, %{})
+          Map.put(acc, key, apply_event(state, ev))
+        end)
+
+      hops = by_uid |> Map.values() |> Enum.sort_by(&Map.get(&1, :index, 999_999))
+      {:ok, hops}
+    end
+  end
+
+  defp apply_event(state, %{"event" => "hop_start", "hop" => hop, "payload" => payload}) do
+    decision = Map.get(payload, "route_decision", %{})
+
+    state
+    |> Map.put_new(:service, Map.get(decision, "service") || Map.get(hop, "service"))
+    |> Map.put_new(:method, Map.get(decision, "method") || Map.get(hop, "method"))
+    |> Map.put_new(:index, Map.get(payload, "index"))
+    |> Map.put_new(:uid, Map.get(hop, "uid"))
+  end
+
+  defp apply_event(state, %{"event" => "hop_stop", "payload" => payload}) do
+    state
+    |> Map.put(:status, :ok)
+    |> Map.put(:latency_ms, Map.get(payload, "latency_ms"))
+  end
+
+  defp apply_event(state, %{"event" => "hop_error", "payload" => payload}) do
+    state
+    |> Map.put(:status, :error)
+    |> Map.put(:latency_ms, Map.get(payload, "latency_ms"))
+    |> Map.put(:reason_code, Map.get(payload, "reason_code") || Map.get(payload, "code"))
+  end
+
+  defp apply_event(state, _), do: state
+
+  defp compare_hop(idx, nil, candidate, _tol), do: %{index: idx, status: :diverged, reason_code: :missing_baseline_hop, baseline: nil, candidate: candidate}
+  defp compare_hop(idx, baseline, nil, _tol), do: %{index: idx, status: :diverged, reason_code: :missing_candidate_hop, baseline: baseline, candidate: nil}
+
+  defp compare_hop(idx, baseline, candidate, tol) do
+    cond do
+      baseline.method != candidate.method ->
+        %{index: idx, status: :diverged, reason_code: :method_mismatch, baseline: baseline, candidate: candidate}
+
+      baseline.service != candidate.service ->
+        %{index: idx, status: :diverged, reason_code: :service_mismatch, baseline: baseline, candidate: candidate}
+
+      Map.get(baseline, :status, :ok) != Map.get(candidate, :status, :ok) ->
+        %{index: idx, status: :diverged, reason_code: :status_mismatch, baseline: baseline, candidate: candidate}
+
+      Map.get(baseline, :reason_code) != Map.get(candidate, :reason_code) ->
+        %{index: idx, status: :diverged, reason_code: :reason_code_mismatch, baseline: baseline, candidate: candidate}
+
+      latency_diverged?(baseline, candidate, tol) ->
+        %{index: idx, status: :diverged, reason_code: :latency_out_of_tolerance, baseline: baseline, candidate: candidate}
+
+      true ->
+        %{index: idx, status: :conformant, reason_code: :none, baseline: baseline, candidate: candidate}
+    end
+  end
+
+  defp latency_diverged?(baseline, candidate, tol) when is_integer(tol) and tol >= 0 do
+    b = Map.get(baseline, :latency_ms)
+    c = Map.get(candidate, :latency_ms)
+
+    case {b, c} do
+      {bi, ci} when is_integer(bi) and is_integer(ci) -> abs(bi - ci) > tol
+      _ -> false
+    end
+  end
+
+  defp mode(opts), do: if(map_size(Map.get(opts, "route_remap", %{})) > 0, do: :remapped, else: :original)
+
+  defp normalize_route_hop(hop) when is_map(hop) do
+    service = Map.get(hop, "service") || Map.get(hop, :service)
+    method = Map.get(hop, "method") || Map.get(hop, :method)
+
+    if is_nil(service) or is_nil(method) do
+      nil
+    else
+      %{
+        "service" => service,
+        "method" => method,
+        "params" => Map.get(hop, "params") || Map.get(hop, :params) || %{}
+      }
+    end
+  end
+
+  defp stringify_keys(map) do
+    Map.new(map, fn {k, v} -> {to_string(k), v} end)
+  end
+
+  defp gen_id do
+    :crypto.strong_rand_bytes(12) |> Base.url_encode64(padding: false)
+  end
+end

--- a/lib/lang/proxy/pipeline.ex
+++ b/lib/lang/proxy/pipeline.ex
@@ -27,14 +27,14 @@ defmodule Lang.Proxy.Pipeline do
   @spec run(Envelope.t(), map()) :: {:ok, [map()]} | {:error, integer(), String.t(), map()}
   def run(%Envelope{params: %{"route" => route} = params} = _env, assigns) when is_list(route) do
     pipeline_id = params["pipeline_id"] || gen_id()
-    do_run(route, Map.put(assigns, :pipeline_id, pipeline_id), [], %{})
+    do_run(route, Map.put(assigns, :pipeline_id, pipeline_id), [], %{}, 0)
   end
 
   def run(_env, _assigns), do: {:error, -32602, "invalid route", %{}}
 
-  defp do_run([], _assigns, acc, _ctx), do: {:ok, Enum.reverse(acc)}
+  defp do_run([], _assigns, acc, _ctx, _hop_index), do: {:ok, Enum.reverse(acc)}
 
-  defp do_run([hop | rest], assigns, acc, ctx) do
+  defp do_run([hop | rest], assigns, acc, ctx, hop_index) do
     hop = normalize_hop(hop)
     bound_params = bind_params(Map.get(hop, :params, %{}), ctx)
     pipeline_id = assigns[:pipeline_id]
@@ -50,7 +50,10 @@ defmodule Lang.Proxy.Pipeline do
          :ok <- maybe_require_intent(env, assigns) do
       started = System.monotonic_time()
       pipeline_id = assigns[:pipeline_id]
-      StreamBridge.hop_start(pipeline_id, prune(env))
+      StreamBridge.hop_start(pipeline_id, prune(env), %{
+        index: hop_index,
+        route_decision: route_decision(env, timeout_ms: hop[:timeout_ms] || hop["timeout_ms"], retries: hop[:retries] || hop["retries"], backoff_ms: hop[:backoff_ms] || hop["backoff_ms"])
+      })
       timeout = hop[:timeout_ms] || hop["timeout_ms"] || Application.get_env(:lang, :proxy_hop_timeout_ms, 5_000)
       retries = hop[:retries] || hop["retries"] || 0
       backoff = hop[:backoff_ms] || hop["backoff_ms"] || 0
@@ -58,13 +61,16 @@ defmodule Lang.Proxy.Pipeline do
       case dispatch_with_retry(env, timeout, retries, backoff) do
         {:ok, res} ->
           stopped = System.monotonic_time()
+          latency_ms = System.convert_time_unit(stopped - started, :native, :millisecond)
           :telemetry.execute([:lang, :proxy, :hop, :stop], %{duration: stopped - started}, %{hop: prune(env)})
-          StreamBridge.hop_stop(pipeline_id, prune(env), res)
+          StreamBridge.hop_stop(pipeline_id, prune(env), res, %{index: hop_index, latency_ms: latency_ms})
           new_ctx = Map.put(ctx, "prev", %{"result" => res, "hop" => prune(env)})
-          do_run(rest, assigns, [%{result: res, hop: prune(env)} | acc], new_ctx)
+          do_run(rest, assigns, [%{result: res, hop: prune(env), latency_ms: latency_ms} | acc], new_ctx, hop_index + 1)
 
         {:error, code, message, data} ->
-          StreamBridge.hop_error(pipeline_id, prune(env), code, message, data)
+          stopped = System.monotonic_time()
+          latency_ms = System.convert_time_unit(stopped - started, :native, :millisecond)
+          StreamBridge.hop_error(pipeline_id, prune(env), code, message, data, %{index: hop_index, latency_ms: latency_ms, reason_code: code})
           {:error, code, message, Map.put(data || %{}, :hop, prune(env))}
       end
     else
@@ -78,6 +84,17 @@ defmodule Lang.Proxy.Pipeline do
 
   defp to_envelope(%{service: s, method: m} = hop) do
     %Lang.Proxy.Envelope{v: 1, service: normalize_service(s), method: m, params: Map.get(hop, :params, %{}), opts: %{}, meta: %{}, stream?: false}
+  end
+
+  defp route_decision(%{service: service, method: method, params: params}, opts) do
+    %{
+      service: service,
+      method: method,
+      params: params,
+      timeout_ms: opts[:timeout_ms] || Application.get_env(:lang, :proxy_hop_timeout_ms, 5_000),
+      retries: opts[:retries] || 0,
+      backoff_ms: opts[:backoff_ms] || 0
+    }
   end
 
   defp normalize_service(s) when is_atom(s), do: s

--- a/lib/lang/proxy/router.ex
+++ b/lib/lang/proxy/router.ex
@@ -12,7 +12,7 @@ defmodule Lang.Proxy.Router do
   alias Lang.Proxy.LSPRouter
   alias Lang.Proxy.Adapters.Telnet
   alias Lang.Proxy.Adapters.SSH
-  alias Lang.Proxy.Pipeline
+  alias Lang.Proxy.{Pipeline, ChainConformance}
 
   @type result :: {:ok, any()} | {:error, integer(), String.t(), map()}
 
@@ -97,6 +97,27 @@ defmodule Lang.Proxy.Router do
     case Pipeline.run(%Envelope{env | params: params}, assigns) do
       {:ok, res} -> {:ok, %{pipeline: res}}
       {:error, code, message, data} -> {:error, code, message, data}
+    end
+  end
+
+  def dispatch(%Envelope{service: :proxy, method: "pipeline.replay", params: params} = env) do
+    assigns = Map.get(env, :meta, %{})
+    source_pipeline_id = params["source_pipeline_id"] || params[:source_pipeline_id]
+
+    case ChainConformance.replay(source_pipeline_id, params, assigns) do
+      {:ok, replay} -> {:ok, replay}
+      {:error, %{code: code, message: message, data: data}} -> {:error, code, message, data}
+      {:error, reason} -> {:error, -32060, "pipeline replay failed", %{reason: inspect(reason)}}
+    end
+  end
+
+  def dispatch(%Envelope{service: :proxy, method: "pipeline.conformance_report", params: params}) do
+    baseline = params["baseline_pipeline_id"] || params[:baseline_pipeline_id]
+    candidate = params["candidate_pipeline_id"] || params[:candidate_pipeline_id]
+
+    case ChainConformance.report(baseline, candidate, params) do
+      {:ok, report} -> {:ok, report}
+      {:error, reason} -> {:error, -32061, "conformance report failed", %{reason: inspect(reason)}}
     end
   end
 

--- a/lib/lang/proxy/stream_bridge.ex
+++ b/lib/lang/proxy/stream_bridge.ex
@@ -5,21 +5,27 @@ defmodule Lang.Proxy.StreamBridge do
 
   def topic(pipeline_id) when is_binary(pipeline_id), do: @prefix <> pipeline_id
 
-  def hop_start(pipeline_id, hop) do
+  def hop_start(pipeline_id, hop), do: hop_start(pipeline_id, hop, %{})
+
+  def hop_start(pipeline_id, hop, meta) do
     Phoenix.PubSub.broadcast(Lang.PubSub, topic(pipeline_id), {:hop_start, hop})
-    Lang.Proxy.StreamCapture.capture(pipeline_id, :hop_start, hop, %{})
+    Lang.Proxy.StreamCapture.capture(pipeline_id, :hop_start, hop, meta || %{})
   end
 
-  def hop_stop(pipeline_id, hop, result) do
+  def hop_stop(pipeline_id, hop, result), do: hop_stop(pipeline_id, hop, result, %{})
+
+  def hop_stop(pipeline_id, hop, result, meta) do
     summary = summarize(result)
     Phoenix.PubSub.broadcast(Lang.PubSub, topic(pipeline_id), {:hop_stop, hop, summary})
-    Lang.Proxy.StreamCapture.capture(pipeline_id, :hop_stop, hop, summary)
+    Lang.Proxy.StreamCapture.capture(pipeline_id, :hop_stop, hop, Map.merge(summary, meta || %{}))
   end
 
-  def hop_error(pipeline_id, hop, code, message, data) do
+  def hop_error(pipeline_id, hop, code, message, data), do: hop_error(pipeline_id, hop, code, message, data, %{})
+
+  def hop_error(pipeline_id, hop, code, message, data, meta) do
     payload = %{code: code, message: message, data: data}
     Phoenix.PubSub.broadcast(Lang.PubSub, topic(pipeline_id), {:hop_error, hop, payload})
-    Lang.Proxy.StreamCapture.capture(pipeline_id, :hop_error, hop, payload)
+    Lang.Proxy.StreamCapture.capture(pipeline_id, :hop_error, hop, Map.merge(payload, meta || %{}))
   end
 
   def hop_partial(pipeline_id, hop, payload) do

--- a/lib/lang/proxy/stream_capture.ex
+++ b/lib/lang/proxy/stream_capture.ex
@@ -25,6 +25,32 @@ defmodule Lang.Proxy.StreamCapture do
 
   def enabled?, do: @enable || Application.get_env(:lang, :enable_proxy_stream_capture, false)
 
+  @doc "Fetch captured stream entries for a pipeline, newest-first."
+  @spec list(binary(), non_neg_integer()) :: {:ok, [map()]} | {:error, term()}
+  def list(pipeline_id, limit \\ @max) when is_binary(pipeline_id) do
+    cond do
+      not enabled?() -> {:error, :capture_disabled}
+      not Lang.Redis.available?() -> {:error, :redis_unavailable}
+      true ->
+        key = "proxy:capture:" <> pipeline_id
+
+        case Lang.Redis.command(["LRANGE", key, "0", Integer.to_string(max(limit - 1, 0))]) do
+          {:ok, rows} when is_list(rows) ->
+            decoded =
+              rows
+              |> Enum.map(&decode_entry/1)
+              |> Enum.filter(&is_map/1)
+
+            {:ok, decoded}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+    end
+  rescue
+    e -> {:error, e}
+  end
+
   defp redact(map) when is_map(map) do
     Map.new(map, fn {k, v} -> {k, redact_value(k, v)} end)
   end
@@ -39,5 +65,13 @@ defmodule Lang.Proxy.StreamCapture do
       redact(v)
     end
   end
-end
 
+  defp decode_entry(json) when is_binary(json) do
+    case Jason.decode(json) do
+      {:ok, map} -> map
+      _ -> nil
+    end
+  end
+
+  defp decode_entry(_), do: nil
+end

--- a/test/lang/proxy/chain_conformance_test.exs
+++ b/test/lang/proxy/chain_conformance_test.exs
@@ -1,0 +1,81 @@
+defmodule Lang.Proxy.ChainConformanceTest do
+  use ExUnit.Case, async: true
+  import Mock
+
+  alias Lang.Proxy.ChainConformance
+
+  describe "replay/3" do
+    test "replays against original captured chain" do
+      captured = [
+        %{
+          "event" => "hop_start",
+          "hop" => %{"uid" => "h1", "service" => :lsp, "method" => "lsp.bootstrap"},
+          "payload" => %{"index" => 0, "route_decision" => %{"service" => :lsp, "method" => "lsp.bootstrap", "params" => %{"workspace" => "/tmp"}}}
+        }
+      ]
+
+      with_mock Lang.Proxy.StreamCapture,
+        list: fn "base-1" -> {:ok, captured} end do
+        with_mock Lang.Proxy.Pipeline,
+          run: fn _env, _assigns -> {:ok, [%{hop: %{service: :lsp, method: "lsp.bootstrap"}, result: %{status: :ok}, latency_ms: 5}]} end do
+          assert {:ok, %{route_mode: :original, remapped: 0, result: [_]}} =
+                   ChainConformance.replay("base-1", %{}, %{})
+        end
+      end
+    end
+
+    test "replays against remapped chain" do
+      captured = [
+        %{
+          "event" => "hop_start",
+          "hop" => %{"uid" => "h1", "service" => :lsp, "method" => "lsp.bootstrap"},
+          "payload" => %{"index" => 0, "route_decision" => %{"service" => :lsp, "method" => "lsp.bootstrap", "params" => %{}}}
+        }
+      ]
+
+      with_mock Lang.Proxy.StreamCapture,
+        list: fn "base-2" -> {:ok, captured} end do
+        with_mock Lang.Proxy.Pipeline,
+          run: fn env, _assigns ->
+            assert [%{"method" => "lsp.bootstrap_ssh"}] = env.params["route"]
+            {:ok, [%{hop: %{service: :lsp, method: "lsp.bootstrap_ssh"}, result: %{status: :ok}, latency_ms: 4}]}
+          end do
+          assert {:ok, %{route_mode: :remapped, remapped: 1}} =
+                   ChainConformance.replay("base-2", %{"route_remap" => %{"lsp.bootstrap" => "lsp.bootstrap_ssh"}}, %{})
+        end
+      end
+    end
+  end
+
+  describe "report/3" do
+    test "reports divergence with reason code by hop" do
+      baseline = [
+        %{"event" => "hop_start", "hop" => %{"uid" => "h1"}, "payload" => %{"index" => 0, "route_decision" => %{"service" => :lsp, "method" => "lsp.bootstrap"}}},
+        %{"event" => "hop_stop", "hop" => %{"uid" => "h1"}, "payload" => %{"latency_ms" => 5}},
+        %{"event" => "hop_start", "hop" => %{"uid" => "h2"}, "payload" => %{"index" => 1, "route_decision" => %{"service" => :lsp, "method" => "lsp.symbols"}}},
+        %{"event" => "hop_stop", "hop" => %{"uid" => "h2"}, "payload" => %{"latency_ms" => 10}}
+      ]
+
+      candidate = [
+        %{"event" => "hop_start", "hop" => %{"uid" => "h1"}, "payload" => %{"index" => 0, "route_decision" => %{"service" => :lsp, "method" => "lsp.bootstrap"}}},
+        %{"event" => "hop_stop", "hop" => %{"uid" => "h1"}, "payload" => %{"latency_ms" => 7}},
+        %{"event" => "hop_start", "hop" => %{"uid" => "h2"}, "payload" => %{"index" => 1, "route_decision" => %{"service" => :lsp, "method" => "lsp.symbols"}}},
+        %{"event" => "hop_error", "hop" => %{"uid" => "h2"}, "payload" => %{"code" => -32050, "reason_code" => -32050, "latency_ms" => 30}}
+      ]
+
+      with_mocks([
+        {Lang.Proxy.StreamCapture, [], [
+          list: fn
+            "baseline" -> {:ok, baseline}
+            "candidate" -> {:ok, candidate}
+          end
+        ]}
+      ]) do
+        assert {:ok, report} = ChainConformance.report("baseline", "candidate", %{"latency_tolerance_ms" => 3})
+        assert report.total_hops == 2
+        assert report.diverged_hops == 1
+        assert Enum.any?(report.hops, &(&1.reason_code == :status_mismatch))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
- Capture hop-by-hop route decisions, per-hop latencies and error reason codes during proxy pipeline execution for observability. 
- Enable replay of captured chains (original or remapped) to exercise resilience scenarios. 
- Provide conformance reports that highlight hop-level divergence reasons between baseline and candidate runs.

### Description
- Instrument `Lang.Proxy.Pipeline` to emit hop index, explicit `route_decision`, measured `latency_ms`, and error `reason_code` via stream events when hops start/stop/error. 
- Extend `Lang.Proxy.StreamBridge` to accept and broadcast metadata-aware `hop_start`, `hop_stop`, and `hop_error` signatures while preserving compatibility shims. 
- Extend `Lang.Proxy.StreamCapture` with `list/2` and JSON decoding to retrieve captured pipeline events from Redis for replay/analysis. 
- Add `Lang.Proxy.ChainConformance` implementing `replay/3` (execute captured or remapped routes) and `report/3` (per-hop conformance with divergence reason codes and latency tolerance). 
- Expose new proxy envelope methods in `Lang.Proxy.Router`: `pipeline.replay` and `pipeline.conformance_report`. 
- Add unit tests at `test/lang/proxy/chain_conformance_test.exs` covering replay (original + remapped) and conformance reporting logic.

### Testing
- Added ExUnit tests in `test/lang/proxy/chain_conformance_test.exs`, but the test suite was not executed in this environment. 
- Attempted to run formatting (`mix format ...`) as an automated preflight, but it failed because `mix` is not available in the execution environment (`/bin/bash: mix: command not found`). 
- No automated ExUnit runs were performed here due to the missing Elixir toolchain; tests should be run in CI or a local dev environment with `mix test` and `mix format`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d3f6a8a4ac832ea7e381c1909b9a4a)