### PR TITLE
Add proxy capture schema/store and replay API endpoints

### DIFF
--- a/lib/lang/application.ex
+++ b/lib/lang/application.ex
@@ -47,6 +47,7 @@ defmodule Lang.Application do
         optional_child({Lang.Conversation.RehearsalEngine, []}),
         optional_child({Lang.Timeline.StateManager, []}),
         optional_child({Lang.Security.RateLimiter, []}),
+        optional_child({Lang.Proxy.CaptureStore, []}),
 
         # AST snapshot store (ETS-backed)
         optional_child({Lang.AST.Store, []}),

--- a/lib/lang/proxy/capture_schema.ex
+++ b/lib/lang/proxy/capture_schema.ex
@@ -1,0 +1,69 @@
+defmodule Lang.Proxy.CaptureSchema do
+  @moduledoc """
+  Canonical schema helpers for proxy capture/replay records.
+
+  Each record contains:
+  - canonical_request (normalized envelope map)
+  - canonical_response (normalized router result map)
+  - route_path
+  - dependency_refs
+  - trace_id / idempotency_key indexes
+  """
+
+  alias Lang.Proxy.Envelope
+
+  @type canonical_request :: %{
+          required(:v) => pos_integer(),
+          required(:service) => atom(),
+          required(:method) => String.t(),
+          required(:params) => map(),
+          required(:opts) => keyword() | map(),
+          required(:meta) => map(),
+          required(:stream) => boolean()
+        }
+
+  @type canonical_response :: %{
+          required(:status) => :ok | :error,
+          required(:payload) => map()
+        }
+
+  @type capture_record :: %{
+          required(:id) => String.t(),
+          required(:inserted_at) => DateTime.t(),
+          required(:trace_id) => String.t() | nil,
+          required(:idempotency_key) => String.t() | nil,
+          required(:route_path) => String.t(),
+          required(:dependency_refs) => [String.t()],
+          required(:canonical_request) => canonical_request(),
+          required(:canonical_response) => canonical_response()
+        }
+
+  @spec canonical_request(Envelope.t()) :: canonical_request()
+  def canonical_request(%Envelope{} = env) do
+    %{
+      v: env.v,
+      service: env.service,
+      method: env.method,
+      params: env.params || %{},
+      opts: env.opts || %{},
+      meta: env.meta || %{},
+      stream: !!env.stream?
+    }
+  end
+
+  @spec canonical_response({:ok, any()} | {:error, integer(), String.t(), map()}) :: canonical_response()
+  def canonical_response({:ok, payload}), do: %{status: :ok, payload: %{result: payload}}
+
+  def canonical_response({:error, code, message, data}) do
+    %{status: :error, payload: %{code: code, message: message, data: data || %{}}}
+  end
+
+  @spec normalize_dependency_refs(any()) :: [String.t()]
+  def normalize_dependency_refs(refs) when is_list(refs) do
+    refs
+    |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
+  end
+
+  def normalize_dependency_refs(_), do: []
+end

--- a/lib/lang/proxy/capture_store.ex
+++ b/lib/lang/proxy/capture_store.ex
@@ -1,0 +1,177 @@
+defmodule Lang.Proxy.CaptureStore do
+  @moduledoc """
+  In-memory capture storage with bounded retention and indexed lookups.
+
+  Uses ETS with three tables:
+  - records by capture id
+  - trace_id -> [capture ids]
+  - idempotency_key -> [capture ids]
+  """
+
+  use GenServer
+
+  alias Lang.Proxy.{CaptureSchema, Envelope, Router}
+
+  @records_table :proxy_capture_records
+  @trace_index_table :proxy_capture_trace_index
+  @idem_index_table :proxy_capture_idem_index
+
+  @default_max_records 500
+  @default_retention_seconds 3600
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    :ets.new(@records_table, [:set, :named_table, :public, read_concurrency: true])
+    :ets.new(@trace_index_table, [:bag, :named_table, :public, read_concurrency: true])
+    :ets.new(@idem_index_table, [:bag, :named_table, :public, read_concurrency: true])
+    {:ok, %{max_records: max_records(), retention_seconds: retention_seconds()}}
+  end
+
+  @spec put_capture(map()) :: {:ok, map()} | {:error, term()}
+  def put_capture(attrs) when is_map(attrs), do: GenServer.call(__MODULE__, {:put_capture, attrs})
+
+  @spec get_capture(String.t()) :: {:ok, map()} | {:error, :not_found}
+  def get_capture(id) when is_binary(id) do
+    purge_expired()
+
+    case :ets.lookup(@records_table, id) do
+      [{^id, record}] -> {:ok, record}
+      _ -> {:error, :not_found}
+    end
+  end
+
+  @spec find_capture(keyword()) :: {:ok, map()} | {:error, :not_found}
+  def find_capture(opts) when is_list(opts) do
+    purge_expired()
+
+    cond do
+      is_binary(opts[:id]) -> get_capture(opts[:id])
+      is_binary(opts[:trace_id]) -> fetch_latest_by_index(@trace_index_table, opts[:trace_id])
+      is_binary(opts[:idempotency_key]) -> fetch_latest_by_index(@idem_index_table, opts[:idempotency_key])
+      true -> {:error, :not_found}
+    end
+  end
+
+  @spec replay_capture(String.t(), :dry | :strict) :: {:ok, map()} | {:error, term()}
+  def replay_capture(id, mode) when mode in [:dry, :strict] do
+    with {:ok, capture} <- get_capture(id) do
+      case mode do
+        :dry ->
+          {:ok, %{mode: :dry, replayed: false, capture: capture}}
+
+        :strict ->
+          with {:ok, env} <- Envelope.new(capture.canonical_request),
+               result <- Router.dispatch(env) do
+            actual = CaptureSchema.canonical_response(result)
+            expected = capture.canonical_response
+
+            {:ok,
+             %{
+               mode: :strict,
+               replayed: true,
+               matched?: actual == expected,
+               expected: expected,
+               actual: actual,
+               capture: capture
+             }}
+          end
+      end
+    end
+  end
+
+  @impl true
+  def handle_call({:put_capture, attrs}, _from, state) do
+    now = DateTime.utc_now()
+    id = Ecto.UUID.generate()
+
+    record = %{
+      id: id,
+      inserted_at: now,
+      expires_at: DateTime.add(now, state.retention_seconds, :second),
+      trace_id: normalize(attrs[:trace_id] || attrs["trace_id"]),
+      idempotency_key: normalize(attrs[:idempotency_key] || attrs["idempotency_key"]),
+      route_path: to_string(attrs[:route_path] || attrs["route_path"] || "unknown"),
+      dependency_refs:
+        CaptureSchema.normalize_dependency_refs(attrs[:dependency_refs] || attrs["dependency_refs"]),
+      canonical_request: attrs[:canonical_request] || attrs["canonical_request"] || %{},
+      canonical_response: attrs[:canonical_response] || attrs["canonical_response"] || %{}
+    }
+
+    :ets.insert(@records_table, {id, record})
+    maybe_index(@trace_index_table, record.trace_id, id)
+    maybe_index(@idem_index_table, record.idempotency_key, id)
+
+    state = enforce_bounds(state)
+    {:reply, {:ok, record}, state}
+  end
+
+  defp fetch_latest_by_index(table, key) do
+    ids = :ets.lookup(table, key) |> Enum.map(fn {_k, id} -> id end)
+
+    ids
+    |> Enum.map(fn id -> case :ets.lookup(@records_table, id) do [{^id, rec}] -> rec; _ -> nil end end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
+    |> List.first()
+    |> case do
+      nil -> {:error, :not_found}
+      rec -> {:ok, rec}
+    end
+  end
+
+  defp maybe_index(_table, nil, _id), do: :ok
+  defp maybe_index(_table, "", _id), do: :ok
+  defp maybe_index(table, key, id), do: :ets.insert(table, {key, id})
+
+  defp normalize(v) when is_binary(v), do: String.trim(v)
+  defp normalize(_), do: nil
+
+  defp max_records,
+    do: Application.get_env(:lang, :proxy_capture_max_records, @default_max_records)
+
+  defp retention_seconds,
+    do: Application.get_env(:lang, :proxy_capture_retention_seconds, @default_retention_seconds)
+
+  defp purge_expired do
+    now = DateTime.utc_now()
+
+    for {_id, rec} <- :ets.tab2list(@records_table), DateTime.compare(rec.expires_at, now) == :lt do
+      delete_record(rec)
+    end
+
+    :ok
+  end
+
+  defp enforce_bounds(state) do
+    purge_expired()
+
+    count = :ets.info(@records_table, :size)
+
+    if count > state.max_records do
+      drop = count - state.max_records
+
+      @records_table
+      |> :ets.tab2list()
+      |> Enum.map(fn {_id, rec} -> rec end)
+      |> Enum.sort_by(& &1.inserted_at, {:asc, DateTime})
+      |> Enum.take(drop)
+      |> Enum.each(&delete_record/1)
+    end
+
+    state
+  end
+
+  defp delete_record(rec) do
+    :ets.delete(@records_table, rec.id)
+    maybe_delete_index(@trace_index_table, rec.trace_id, rec.id)
+    maybe_delete_index(@idem_index_table, rec.idempotency_key, rec.id)
+  end
+
+  defp maybe_delete_index(_table, nil, _id), do: :ok
+  defp maybe_delete_index(_table, "", _id), do: :ok
+  defp maybe_delete_index(table, key, id), do: :ets.delete_object(table, {key, id})
+end

--- a/lib/lang_web/api/v2/proxy_controller.ex
+++ b/lib/lang_web/api/v2/proxy_controller.ex
@@ -1,0 +1,78 @@
+defmodule LangWeb.Api.V2.ProxyController do
+  use LangWeb, :controller
+
+  alias Lang.Proxy.{CaptureSchema, CaptureStore, Envelope, Router}
+
+  def call(conn, params) do
+    with {:ok, env} <- Envelope.new(params),
+         result <- Router.dispatch(env),
+         {:ok, capture} <- persist_capture(conn, env, result, params) do
+      render_proxy_result(conn, result, capture.id)
+    else
+      {:error, reason} -> conn |> put_status(:bad_request) |> json(%{error: inspect(reason)})
+    end
+  end
+
+  # Existing route placeholders; keep simple wrappers.
+  def issue_intent(conn, params), do: call(conn, params)
+  def run_session(conn, params), do: call(conn, params)
+
+  def get_capture(conn, %{"id" => id}) do
+    case CaptureStore.get_capture(id) do
+      {:ok, capture} -> json(conn, %{capture: capture})
+      {:error, :not_found} -> conn |> put_status(:not_found) |> json(%{error: "capture_not_found"})
+    end
+  end
+
+  def find_capture(conn, params) do
+    opts = [trace_id: params["trace_id"], idempotency_key: params["idempotency_key"]]
+
+    case CaptureStore.find_capture(opts) do
+      {:ok, capture} -> json(conn, %{capture: capture})
+      {:error, :not_found} -> conn |> put_status(:not_found) |> json(%{error: "capture_not_found"})
+    end
+  end
+
+  def replay_capture(conn, %{"id" => id} = params) do
+    mode = parse_mode(params["mode"])
+
+    case CaptureStore.replay_capture(id, mode) do
+      {:ok, replay} -> json(conn, %{replay: replay})
+      {:error, :not_found} -> conn |> put_status(:not_found) |> json(%{error: "capture_not_found"})
+      {:error, reason} -> conn |> put_status(:unprocessable_entity) |> json(%{error: inspect(reason)})
+    end
+  end
+
+  defp parse_mode("strict"), do: :strict
+  defp parse_mode(:strict), do: :strict
+  defp parse_mode(_), do: :dry
+
+  defp persist_capture(conn, env, result, params) do
+    trace_id = params["trace_id"] || get_req_header(conn, "x-trace-id") |> List.first()
+
+    idem_key =
+      params["idempotency_key"] ||
+        get_req_header(conn, "idempotency-key") |> List.first()
+
+    route_path = params["route_path"] || get_in(params, ["params", "route"]) || env.method
+
+    CaptureStore.put_capture(%{
+      trace_id: trace_id,
+      idempotency_key: idem_key,
+      route_path: route_path,
+      dependency_refs: params["dependency_refs"] || [],
+      canonical_request: CaptureSchema.canonical_request(env),
+      canonical_response: CaptureSchema.canonical_response(result)
+    })
+  end
+
+  defp render_proxy_result(conn, {:ok, payload}, capture_id) do
+    json(conn, %{ok: true, result: payload, capture_id: capture_id})
+  end
+
+  defp render_proxy_result(conn, {:error, code, message, data}, capture_id) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{ok: false, error: %{code: code, message: message, data: data}, capture_id: capture_id})
+  end
+end

--- a/lib/lang_web/router.ex
+++ b/lib/lang_web/router.ex
@@ -266,6 +266,9 @@ defmodule LangWeb.Router do
     post "/proxy", ProxyController, :call
     post "/proxy/intent", ProxyController, :issue_intent
     post "/proxy/session", ProxyController, :run_session
+    get "/proxy/captures/:id", ProxyController, :get_capture
+    get "/proxy/captures", ProxyController, :find_capture
+    post "/proxy/captures/:id/replay", ProxyController, :replay_capture
 
     # MCP JSON:API (AshJsonApi) - mounting Domain resources
     forward "/mcp", AshJsonApi.Router, domains: [Lang.MCP]


### PR DESCRIPTION
### Motivation

- Provide a canonical replay schema for proxy requests and responses including route path and dependency references to enable deterministic replay and inspection.
- Persist proxy capture records with bounded retention and fast indexed lookup by `trace_id` and `idempotency_key` to support debugging and idempotent operations.
- Expose API endpoints to retrieve captures and trigger replays in `dry` and `strict` modes for validation and troubleshooting.

### Description

- Added `Lang.Proxy.CaptureSchema` to produce canonical request/response shapes and to normalize dependency references. 
- Implemented `Lang.Proxy.CaptureStore` as an ETS-backed `GenServer` that stores records, maintains `trace_id` and `idempotency_key` indexes, enforces a max-records bound, and purges expired entries. 
- Added `LangWeb.Api.V2.ProxyController` which persists captures on proxy calls and exposes `GET /api/v2/proxy/captures/:id`, `GET /api/v2/proxy/captures?trace_id=...|idempotency_key=...`, and `POST /api/v2/proxy/captures/:id/replay` with `dry` and `strict` replay semantics. 
- Wired the capture store into the application supervision tree and added corresponding router entries for the new endpoints. 

### Testing

- `git diff --check` passed without issues. 
- Attempted to run `mix compile` but it could not be executed in this environment because `mix` is not installed, so compilation and test suites were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d3f69bf1e0832eb5e797fb97621bcb)