### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Atom Exhaustion DoS in orchestrator worker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-30 - Atom Exhaustion Denial of Service
+**Vulnerability:** Use of `String.to_atom/1` with unsanitized user input creates an atom for every unique input. Atoms are not garbage collected, leading to atom table exhaustion and application crash (Denial of Service).
+**Learning:** Elixir/Erlang atom table is limited (typically 1,048,576). Unsafe atom creation from dynamic sources (like DB, APIs, or job arguments) is a classic DoS vector.
+**Prevention:** Always use `String.to_existing_atom/1` when converting untrusted or dynamic strings to atoms, and handle the potential `ArgumentError`.

--- a/lib/lang/workers/orchestrator_worker.ex
+++ b/lib/lang/workers/orchestrator_worker.ex
@@ -20,7 +20,7 @@ defmodule Lang.Workers.OrchestratorWorker do
     start_time = System.monotonic_time(:millisecond)
 
     try do
-      result = execute_task(String.to_atom(env), String.to_atom(task), args)
+      result = execute_task(safe_to_atom(env), safe_to_atom(task), args)
 
       duration = System.monotonic_time(:millisecond) - start_time
 
@@ -997,7 +997,7 @@ defmodule Lang.Workers.OrchestratorWorker do
           task: task,
           triggered_by: completed_task
         }
-        |> __MODULE__.new(queue: queue_for_env(String.to_atom(env)))
+        |> __MODULE__.new(queue: queue_for_env(safe_to_atom(env)))
         |> Oban.insert!()
       end
     end)
@@ -1005,7 +1005,7 @@ defmodule Lang.Workers.OrchestratorWorker do
 
   defp get_task_dependencies(env) do
     # Return task dependencies for the environment
-    case String.to_atom(env) do
+    case safe_to_atom(env) do
       :text ->
         %{
           implement_parsers: [:generate_spec],
@@ -1042,6 +1042,14 @@ defmodule Lang.Workers.OrchestratorWorker do
   end
 
   defp queue_for_env(env) when is_binary(env) do
-    queue_for_env(String.to_atom(env))
+    queue_for_env(safe_to_atom(env))
+  end
+
+  defp safe_to_atom(string) when is_binary(string) do
+    String.to_existing_atom(string)
+  rescue
+    ArgumentError ->
+      Logger.warning("Security Warning: Attempted to create unsafe atom from string: #{inspect(string)}")
+      :unknown_task_or_env
   end
 end


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Used `String.to_atom/1` with unsanitized user input (from Oban job arguments). Atoms are not garbage collected in Erlang/Elixir, leading to atom table exhaustion and application crash (Denial of Service).
🎯 Impact: Attackers or malformed jobs could exhaust the VM's atom table, causing a complete system outage.
🔧 Fix: Replaced `String.to_atom/1` with a `safe_to_atom/1` helper that uses `String.to_existing_atom/1` and safely rescues `ArgumentError` to avoid creating new atoms dynamically, logging a security warning instead.
✅ Verification: Ensure the orchestrator tasks fail safely with an invalid task string rather than crashing the VM.

---
*PR created automatically by Jules for task [9405712818440287707](https://jules.google.com/task/9405712818440287707) started by @locsic*