### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service via Atom Table Exhaustion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - [Denial of Service via Atom Table Exhaustion]
+**Vulnerability:** Found `String.to_atom/1` being called directly on untrusted background job arguments (e.g., `args["period_type"]`) in Oban workers.
+**Learning:** In Elixir, atoms are not garbage collected. Creating atoms dynamically from arbitrary, untrusted input strings allows attackers to slowly or rapidly fill the atom table limit (default 1,048,576), crashing the entire Erlang VM and causing a Denial of Service.
+**Prevention:** Always use `String.to_existing_atom/1` for untrusted input. Catch `ArgumentError` to gracefully handle cases where the string isn't an existing atom, providing a default fallback and optionally logging a security warning.

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -118,9 +118,18 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   # Private handlers
 
+  defp parse_period_type(nil), do: :daily
+  defp parse_period_type(type_str) when is_binary(type_str) do
+    String.to_existing_atom(type_str)
+  rescue
+    ArgumentError ->
+      Logger.warning("Security Warning: Invalid period_type atom attempted: #{inspect(type_str)}")
+      :daily
+  end
+
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = parse_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -143,7 +152,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = parse_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -189,7 +198,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = parse_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Denial of Service via Atom Table Exhaustion

🚨 Severity: CRITICAL
💡 Vulnerability: Direct use of `String.to_atom/1` on untrusted background job arguments (Oban).
🎯 Impact: Attackers can exhaust the Erlang VM's atom table by submitting a large number of arbitrary strings, causing an application-wide Denial of Service (DoS).
🔧 Fix: Replaced `String.to_atom/1` with `String.to_existing_atom/1` using a resilient `parse_period_type/1` helper that safely catches `ArgumentError` and falls back to a default value without crashing the worker process. Recorded learning in `.jules/sentinel.md`.
✅ Verification: Code review to ensure only valid existing atoms are parsed. The tests have network limitations in the environment but standard execution should succeed unaffected.

---
*PR created automatically by Jules for task [3427667249209692878](https://jules.google.com/task/3427667249209692878) started by @locsic*