### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Atom Exhaustion in ProductivityMetricsWorker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - String.to_atom used on external job arguments in Oban Worker
+**Vulnerability:** Found `String.to_atom` being used on Oban job arguments (`args["period_type"]`) in `Lang.Workers.ProductivityMetricsWorker`.
+**Learning:** Oban job arguments can be manipulated or constructed externally in a way that allows arbitrary strings to be fed into `String.to_atom`. Elixir atoms are not garbage collected, leading to atom table exhaustion and potentially crashing the VM (Denial of Service).
+**Prevention:** Always use `String.to_existing_atom/1` for parsing dynamically provided string values into atoms, especially from job arguments, external requests, or database fields representing enums. Catch the potential `ArgumentError` when doing so.

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -120,7 +120,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = String.to_existing_atom(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -143,7 +143,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = String.to_existing_atom(args["period_type"])
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -189,7 +189,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = String.to_existing_atom(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `String.to_atom/1` was used on external untrusted Oban job arguments (`args["period_type"]`). Elixir atoms are not garbage collected, so parsing untrusted strings directly to atoms creates a memory leak vector.
🎯 Impact: An attacker or a bug could continuously inject unknown string payloads, exhausting the VM's atom table and causing a Denial of Service (DoS) crash.
🔧 Fix: Replaced `String.to_atom` with `String.to_existing_atom` on lines 123, 146, and 192 in `lib/lang/workers/productivity_metrics_worker.ex`. Unrecognized strings will now raise an `ArgumentError` which is caught by Oban's standard execution error handling, allowing the app to fail safely instead of crashing. Added learning to `.jules/sentinel.md`.
✅ Verification: Tested the worker parsing behavior via tests (using `SKIP_NIFS=1 MISE_HTTP_TIMEOUT=120 MISE_FETCH_REMOTE_VERSIONS_TIMEOUT=120 mise exec -- mix test`). Code format, linting, and testing are passing correctly.

---
*PR created automatically by Jules for task [1467630818492433037](https://jules.google.com/task/1467630818492433037) started by @locsic*