### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Atom Table Exhaustion (DoS) vulnerability in workers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Atom Table Exhaustion (Denial of Service)]
+**Vulnerability:** Found `String.to_atom/1` used on untrusted user input directly in background Oban workers (e.g., `Lang.Workers.OrchestratorWorker` and `Lang.Workers.ProductivityMetricsWorker`).
+**Learning:** `String.to_atom/1` creates a new atom that is never garbage collected, meaning attackers can send randomized strings to these endpoints/jobs to exhaust the beam's atom table and crash the application.
+**Prevention:** Never use `String.to_atom/1` on strings derived from user input or job arguments. Use a safer mechanism: try to convert via `String.to_existing_atom/1` inside a `try/rescue` block that captures `ArgumentError` and safely falls back (or logs a security warning) rather than continuing business logic.

--- a/lib/lang/workers/orchestrator_worker.ex
+++ b/lib/lang/workers/orchestrator_worker.ex
@@ -20,7 +20,14 @@ defmodule Lang.Workers.OrchestratorWorker do
     start_time = System.monotonic_time(:millisecond)
 
     try do
-      result = execute_task(String.to_atom(env), String.to_atom(task), args)
+      env_atom = safe_to_atom(env)
+      task_atom = safe_to_atom(task)
+
+      if is_nil(env_atom) or is_nil(task_atom) do
+        raise "Invalid environment or task string (atom exhaustion protection)"
+      end
+
+      result = execute_task(env_atom, task_atom, args)
 
       duration = System.monotonic_time(:millisecond) - start_time
 
@@ -992,12 +999,14 @@ defmodule Lang.Workers.OrchestratorWorker do
       if all_dependencies_completed?(task, dependencies, env) do
         Logger.info("Triggering dependent task #{task} for #{env}")
 
+        env_atom = safe_to_atom(env) || :default
+
         %{
           environment: env,
           task: task,
           triggered_by: completed_task
         }
-        |> __MODULE__.new(queue: queue_for_env(String.to_atom(env)))
+        |> __MODULE__.new(queue: queue_for_env(env_atom))
         |> Oban.insert!()
       end
     end)
@@ -1005,7 +1014,7 @@ defmodule Lang.Workers.OrchestratorWorker do
 
   defp get_task_dependencies(env) do
     # Return task dependencies for the environment
-    case String.to_atom(env) do
+    case safe_to_atom(env) do
       :text ->
         %{
           implement_parsers: [:generate_spec],
@@ -1042,6 +1051,18 @@ defmodule Lang.Workers.OrchestratorWorker do
   end
 
   defp queue_for_env(env) when is_binary(env) do
-    queue_for_env(String.to_atom(env))
+    queue_for_env(safe_to_atom(env) || :default)
+  end
+
+  defp safe_to_atom(nil), do: nil
+  defp safe_to_atom(val) when is_atom(val), do: val
+  defp safe_to_atom(val) when is_binary(val) do
+    try do
+      String.to_existing_atom(val)
+    rescue
+      ArgumentError ->
+        Logger.warning("Security Warning: Attempted to convert unknown string to atom: #{inspect(val)}. Potential Atom Table Exhaustion attack.")
+        nil
+    end
   end
 end

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -120,8 +120,12 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_to_atom(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
+
+    if is_nil(period_type) do
+      raise ArgumentError, "Invalid period_type string (atom exhaustion protection)"
+    end
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
 
@@ -143,9 +147,13 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = safe_to_atom(args["period_type"])
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
+
+    if is_nil(period_type) do
+      raise ArgumentError, "Invalid period_type string (atom exhaustion protection)"
+    end
 
     Logger.info("Generating efficiency report for #{period_type} on #{date}")
 
@@ -189,8 +197,12 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_to_atom(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
+
+    if is_nil(period_type) do
+      raise ArgumentError, "Invalid period_type string (atom exhaustion protection)"
+    end
 
     Logger.info("Aggregating organization metrics for #{organization_id}")
 
@@ -541,5 +553,17 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
     start_dt = DateTime.new!(start_date, ~T[00:00:00], "Etc/UTC")
     end_dt = DateTime.new!(end_date, ~T[23:59:59], "Etc/UTC")
     {start_dt, end_dt}
+  end
+
+  defp safe_to_atom(nil), do: nil
+  defp safe_to_atom(val) when is_atom(val), do: val
+  defp safe_to_atom(val) when is_binary(val) do
+    try do
+      String.to_existing_atom(val)
+    rescue
+      ArgumentError ->
+        Logger.warning("Security Warning: Attempted to convert unknown string to atom: #{inspect(val)}. Potential Atom Table Exhaustion attack.")
+        nil
+    end
   end
 end


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `String.to_atom/1` was used directly on `env`, `task`, and `period_type` strings from incoming Oban job arguments in `Lang.Workers.OrchestratorWorker` and `Lang.Workers.ProductivityMetricsWorker`.
🎯 Impact: Attackers could send an overwhelming number of random string arguments to these workers. Because atoms are never garbage collected by the Erlang VM, this would quickly exhaust the atom table (limit typically ~1 million) and cause an application-wide crash (Denial of Service).
🔧 Fix: Replaced `String.to_atom/1` with a private `safe_to_atom/1` helper. This helper uses `String.to_existing_atom/1` wrapped in a `try/rescue` block that captures `ArgumentError`. If the atom doesn't exist, it safely logs a security warning and returns `nil`, and the execution raises an error safely, halting before reaching business logic.
✅ Verification: Ensure the background jobs correctly process known environments/tasks (since those atoms are defined at compile time or initialization) but fail immediately without memory leaks when provided with random malicious strings.

---
*PR created automatically by Jules for task [9153534385765184830](https://jules.google.com/task/9153534385765184830) started by @locsic*