### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Atom Exhaustion DoS in Analytics Worker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-04 - [Prevent Atom Exhaustion DoS in Background Workers]
+**Vulnerability:** Untrusted external inputs from Oban background job arguments were being dynamically converted to atoms using `String.to_atom/1`.
+**Learning:** Atoms are not garbage collected in Elixir/Erlang. Processing external strings via `String.to_atom/1` exposes the application to atom table exhaustion, ultimately causing an uncontrollable VM crash.
+**Prevention:** Consistently use `String.to_existing_atom/1` inside `try/rescue` blocks for any dynamic input conversion, returning safe default atoms for `ArgumentError`s and logging the attempts.

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -118,9 +118,19 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   # Private handlers
 
+  defp parse_period_type(type_str) do
+    try do
+      String.to_existing_atom(type_str)
+    rescue
+      ArgumentError ->
+        Logger.warning("Security Warning: Attempted atom exhaustion with period_type: #{inspect(type_str)}")
+        :daily
+    end
+  end
+
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = parse_period_type(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -143,7 +153,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = parse_period_type(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -189,7 +199,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = parse_period_type(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Atom Exhaustion DoS vulnerability via untrusted inputs (`args["period_type"]`) dynamically converted to un-garbage-collected atoms using `String.to_atom/1`.
🎯 **Impact**: An attacker could crash the Elixir application (Denial of Service) by continually queueing or processing jobs with arbitrarily unique string arguments for the period type, eventually exhausting the Erlang VM's atom table limit.
🔧 **Fix**: Substituted the unsafe parsing in `lib/lang/workers/productivity_metrics_worker.ex` with a new `parse_period_type/1` function that safely relies on `String.to_existing_atom/1` inside an isolated `try/rescue` block. Invalid inputs are logged and gracefully fall back to a safe `:daily` default atom.
✅ **Verification**: Validate that standard background analytics jobs successfully run and parse `"daily"`, `"weekly"`, etc., into valid atoms, while unknown values safely default instead of crashing or generating atoms indefinitely.

---
*PR created automatically by Jules for task [4534304428239497785](https://jules.google.com/task/4534304428239497785) started by @locsic*