### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Atom Table Exhaustion DoS in Oban Workers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Atom Table Exhaustion in Oban Workers
+**Vulnerability:** Found `String.to_atom/1` used to parse untrusted Job arguments (`args["period_type"]`, `args["granularity"]`) in `Lang.Workers.ProductivityMetricsWorker` and `Lang.Workers.BillingAggregateUsageWorker`.
+**Learning:** Elixir's atom table is not garbage-collected, and dynamically generating atoms from user-provided or external inputs can quickly lead to memory exhaustion and a Denial of Service (DoS) crash.
+**Prevention:** Always use `String.to_existing_atom/1` for untrusted string inputs, wrapping the call in a `try/rescue` block targeting `ArgumentError` to safely fallback or reject invalid data.

--- a/lib/lang/workers/billing_aggregate_usage_worker.ex
+++ b/lib/lang/workers/billing_aggregate_usage_worker.ex
@@ -7,7 +7,7 @@ defmodule Lang.Workers.BillingAggregateUsageWorker do
   @impl true
   def perform(%Oban.Job{args: args}) do
     org_id = args["organization_id"]
-    gran = (args["granularity"] || "hour") |> to_string() |> String.to_atom()
+    gran = safe_to_atom(args["granularity"] || "hour", :hour)
     now = DateTime.utc_now()
     {period_start, period_end} = period_bounds(now, gran)
 
@@ -98,4 +98,18 @@ defmodule Lang.Workers.BillingAggregateUsageWorker do
 
   defp maybe_org(queryable, nil), do: queryable
   defp maybe_org(queryable, org), do: AshHelpers.scope_to_org(queryable, org)
+
+  defp safe_to_atom(nil, default_value), do: default_value
+
+  defp safe_to_atom(string_value, default_value) when is_binary(string_value) do
+    try do
+      String.to_existing_atom(string_value)
+    rescue
+      ArgumentError ->
+        Logger.warning("Security Warning: Attempted atom table exhaustion with string: #{inspect(string_value)}")
+        default_value
+    end
+  end
+
+  defp safe_to_atom(atom_value, _) when is_atom(atom_value), do: atom_value
 end

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -120,7 +120,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_to_atom(args["period_type"] || "daily", :daily)
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -143,7 +143,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = safe_to_atom(args["period_type"], :daily)
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -189,7 +189,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_to_atom(args["period_type"] || "daily", :daily)
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")
@@ -542,4 +542,18 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
     end_dt = DateTime.new!(end_date, ~T[23:59:59], "Etc/UTC")
     {start_dt, end_dt}
   end
+
+  defp safe_to_atom(nil, default_value), do: default_value
+
+  defp safe_to_atom(string_value, default_value) when is_binary(string_value) do
+    try do
+      String.to_existing_atom(string_value)
+    rescue
+      ArgumentError ->
+        Logger.warning("Security Warning: Attempted atom table exhaustion with string: #{inspect(string_value)}")
+        default_value
+    end
+  end
+
+  defp safe_to_atom(atom_value, _) when is_atom(atom_value), do: atom_value
 end


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:** Atom Table Exhaustion (Denial of Service)
Both `Lang.Workers.ProductivityMetricsWorker` and `Lang.Workers.BillingAggregateUsageWorker` were using `String.to_atom/1` to dynamically convert arbitrary string data received from Oban Job arguments (e.g., `args["period_type"]`, `args["granularity"]`) into atoms.

🎯 **Impact:** 
The Erlang VM (BEAM) does not garbage-collect atoms. If an attacker or a runaway process submits jobs with unique, unbounded string values for these fields, it will rapidly exhaust the VM's atom table limit (default 1,048,576), leading to an unrecoverable crash of the entire Elixir application node.

🔧 **Fix:**
- Implemented a private `safe_to_atom/2` helper function in both workers.
- Replaced `String.to_atom/1` with `String.to_existing_atom/1`.
- Added a `try/rescue` block targeting `ArgumentError` to safely catch invalid/malicious strings that haven't been registered as atoms.
- Logged a security warning upon catching malicious input and gracefully fell back to a default value (e.g., `:daily` or `:hour`) to ensure continuous job processing.
- Logged findings in `.jules/sentinel.md`.

✅ **Verification:**
- Code review performed to verify correct exception handling.
- Verified manual fallback logic prevents worker crashes on invalid data.

---
*PR created automatically by Jules for task [17149234298777684461](https://jules.google.com/task/17149234298777684461) started by @locsic*