### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix atom exhaustion DoS in orchestrator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - [Atom Table Exhaustion DoS via External Input in Oban Job]
+**Vulnerability:** User-controlled input (like environment or task parameters) was passed to `String.to_atom/1` in `Lang.Workers.OrchestratorWorker.perform/1`, creating a Denial of Service vulnerability via atom table exhaustion.
+**Learning:** `String.to_atom/1` does not garage collect generated atoms, eventually crashing the VM. Using `try/rescue` to isolate the `ArgumentError` when calling `String.to_existing_atom/1` is essential so that a broad rescue block doesn't mistakenly hide core business logic exceptions.
+**Prevention:** Always use `String.to_existing_atom/1` for parsing untrusted input into atoms, wrap the conversion inside an isolated `try/rescue` block, and fail gracefully if the input is not a known atom.

--- a/lib/lang/workers/orchestrator_worker.ex
+++ b/lib/lang/workers/orchestrator_worker.ex
@@ -19,32 +19,42 @@ defmodule Lang.Workers.OrchestratorWorker do
 
     start_time = System.monotonic_time(:millisecond)
 
-    try do
-      result = execute_task(String.to_atom(env), String.to_atom(task), args)
+    env_atom = safe_to_existing_atom(env)
+    task_atom = safe_to_existing_atom(task)
 
-      duration = System.monotonic_time(:millisecond) - start_time
+    if is_nil(env_atom) or is_nil(task_atom) do
+      error = "Invalid environment or task atom"
+      Logger.warning("#{error}: env=#{inspect(env)}, task=#{inspect(task)}")
+      Master.notify_job_failed(args["job_id"], error)
+      {:error, error}
+    else
+      try do
+        result = execute_task(env_atom, task_atom, args)
 
-      Logger.info("Successfully completed #{task} for #{env} in #{duration}ms")
+        duration = System.monotonic_time(:millisecond) - start_time
 
-      # Notify master of completion
-      Master.notify_job_completed(args["job_id"])
+        Logger.info("Successfully completed #{task} for #{env} in #{duration}ms")
 
-      # Broadcast completion event
-      Phoenix.PubSub.broadcast(
-        Lang.PubSub,
-        "orchestration:updates",
-        {:task_completed, env, task, result, duration}
-      )
+        # Notify master of completion
+        Master.notify_job_completed(args["job_id"])
 
-      # Trigger dependent tasks
-      trigger_dependent_tasks(env, task, args)
+        # Broadcast completion event
+        Phoenix.PubSub.broadcast(
+          Lang.PubSub,
+          "orchestration:updates",
+          {:task_completed, env, task, result, duration}
+        )
 
-      :ok
-    rescue
-      error ->
-        Logger.error("Failed to execute #{task} for #{env}: #{inspect(error)}")
-        Master.notify_job_failed(args["job_id"], error)
-        {:error, error}
+        # Trigger dependent tasks
+        trigger_dependent_tasks(env, task, args)
+
+        :ok
+      rescue
+        error ->
+          Logger.error("Failed to execute #{task} for #{env}: #{inspect(error)}")
+          Master.notify_job_failed(args["job_id"], error)
+          {:error, error}
+      end
     end
   end
 
@@ -997,7 +1007,7 @@ defmodule Lang.Workers.OrchestratorWorker do
           task: task,
           triggered_by: completed_task
         }
-        |> __MODULE__.new(queue: queue_for_env(String.to_atom(env)))
+        |> __MODULE__.new(queue: queue_for_env(env))
         |> Oban.insert!()
       end
     end)
@@ -1005,7 +1015,7 @@ defmodule Lang.Workers.OrchestratorWorker do
 
   defp get_task_dependencies(env) do
     # Return task dependencies for the environment
-    case String.to_atom(env) do
+    case safe_to_existing_atom(env) do
       :text ->
         %{
           implement_parsers: [:generate_spec],
@@ -1042,6 +1052,17 @@ defmodule Lang.Workers.OrchestratorWorker do
   end
 
   defp queue_for_env(env) when is_binary(env) do
-    queue_for_env(String.to_atom(env))
+    queue_for_env(safe_to_existing_atom(env))
   end
+
+  defp safe_to_existing_atom(string) when is_binary(string) do
+    try do
+      String.to_existing_atom(string)
+    rescue
+      ArgumentError ->
+        nil
+    end
+  end
+
+  defp safe_to_existing_atom(atom) when is_atom(atom), do: atom
 end


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Atom Table Exhaustion (Denial of Service) via `String.to_atom/1` on untrusted inputs in `Lang.Workers.OrchestratorWorker`.
🎯 **Impact:** Maliciously crafted input (task or environment strings) passed into background jobs could fill up the Erlang VM's atom table, eventually crashing the entire node.
🔧 **Fix:** Replaced `String.to_atom/1` with a `safe_to_existing_atom/1` helper that wraps `String.to_existing_atom/1` in an isolated `try/rescue` block, ensuring no new atoms are generated and invalid inputs are gracefully caught without masking core execution errors.
✅ **Verification:** Verified via Git diff that `safe_to_existing_atom/1` is correctly used in place of `String.to_atom/1` and that job failures are logged properly when a bad atom is provided.

---
*PR created automatically by Jules for task [8954403421381566197](https://jules.google.com/task/8954403421381566197) started by @locsic*