### PR TITLE
🛡️ Sentinel: [HIGH] Fix Atom Table Exhaustion DoS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - DoS via Atom Table Exhaustion in Oban Workers
+**Vulnerability:** Untrusted string input (e.g., Oban job arguments like `period_type`) was being converted directly to atoms using `String.to_atom/1`. This created a critical Denial of Service (DoS) vulnerability due to atom table exhaustion, as atoms in Elixir are never garbage collected.
+**Learning:** Oban job arguments, even if seemingly internal, must be treated as untrusted external input because they could be crafted or manipulated. Directly converting string arguments to atoms using `String.to_atom/1` poses a severe DoS risk. The `try/rescue` block must be localized just around `String.to_existing_atom/1` to prevent masking broader `ArgumentError`s in the application.
+**Prevention:** Always use `String.to_existing_atom/1` instead of `String.to_atom/1` when converting string input to atoms. Handle the `ArgumentError` exception gracefully (e.g., by logging a security warning and falling back to a safe default value) to protect the application while identifying potential attacks.

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -116,11 +116,25 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
     |> Oban.insert()
   end
 
+
+  # Helper for safe atom conversion to prevent DoS via atom table exhaustion
+  defp safe_period_type(nil), do: :daily
+  defp safe_period_type(period_str) do
+    try do
+      String.to_existing_atom(period_str)
+    rescue
+      ArgumentError ->
+        Logger.warning("Security Warning: Attempted atom exhaustion with period_type: #{inspect(period_str)}")
+        :daily
+    end
+  end
+
   # Private handlers
+
 
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -143,7 +157,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = safe_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -189,7 +203,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Untrusted string input (e.g., Oban job arguments like `period_type`) was being converted directly to atoms using `String.to_atom/1` in `lib/lang/workers/productivity_metrics_worker.ex`. Because atoms in Elixir are never garbage collected, a malicious or malfunctioning upstream producer could exhaust the atom table by providing unique `period_type` strings, thereby causing an application-wide Denial of Service (DoS) crash.
🎯 **Impact:** Potential for an unauthenticated or low-privilege actor (or misconfigured system) to completely crash the underlying Erlang VM, causing widespread platform downtime and disruption.
🔧 **Fix:** Introduced a localized `safe_period_type/1` helper function that safely leverages `String.to_existing_atom/1` inside a targeted `try/rescue` block. This prevents creation of arbitrary atoms, logs a security warning, and gracefully falls back to a `:daily` atom when encountering unrecognized values.
✅ **Verification:** Validated that the helper function safely translates known valid string strings into atoms and robustly handles un-existing atoms without blowing up the application. Code passes CI format and testing. Added findings to Sentinel's internal `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [3150214053022111760](https://jules.google.com/task/3150214053022111760) started by @locsic*