### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Atom Exhaustion in Background Workers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-22 - [Security] Prevent Atom Table Exhaustion in Workers
+**Vulnerability:** Untrusted external inputs for environments and tasks in background jobs were being dynamically converted to atoms using String.to_atom/1. Since the BEAM VM atom table is limited and not garbage collected, malicious inputs could crash the application by filling the table.
+**Learning:** Elixir background jobs (Oban) accepting external string parameters must be especially careful when converting them to symbols used for function dispatching or queue naming.
+**Prevention:** Always use String.to_existing_atom/1 wrapped in an isolated try/rescue block when parsing dynamically-supplied system environment or task parameters, rather than String.to_atom/1.

--- a/lib/lang/workers/orchestrator_worker.ex
+++ b/lib/lang/workers/orchestrator_worker.ex
@@ -19,8 +19,30 @@ defmodule Lang.Workers.OrchestratorWorker do
 
     start_time = System.monotonic_time(:millisecond)
 
+    env_atom =
+      try do
+        String.to_existing_atom(env)
+      rescue
+        ArgumentError ->
+          Logger.warning("Security Warning: Unrecognized environment '#{env}' preventing atom exhaustion.")
+          :error
+      end
+
+    task_atom =
+      try do
+        String.to_existing_atom(task)
+      rescue
+        ArgumentError ->
+          Logger.warning("Security Warning: Unrecognized task '#{task}' preventing atom exhaustion.")
+          :error
+      end
+
     try do
-      result = execute_task(String.to_atom(env), String.to_atom(task), args)
+      if env_atom == :error or task_atom == :error do
+        raise ArgumentError, "Invalid environment '#{env}' or task '#{task}'"
+      end
+
+      result = execute_task(env_atom, task_atom, args)
 
       duration = System.monotonic_time(:millisecond) - start_time
 
@@ -997,15 +1019,22 @@ defmodule Lang.Workers.OrchestratorWorker do
           task: task,
           triggered_by: completed_task
         }
-        |> __MODULE__.new(queue: queue_for_env(String.to_atom(env)))
+        |> __MODULE__.new(queue: queue_for_env(env))
         |> Oban.insert!()
       end
     end)
   end
 
   defp get_task_dependencies(env) do
+    env_atom =
+      try do
+        String.to_existing_atom(env)
+      rescue
+        ArgumentError -> :error
+      end
+
     # Return task dependencies for the environment
-    case String.to_atom(env) do
+    case env_atom do
       :text ->
         %{
           implement_parsers: [:generate_spec],
@@ -1042,6 +1071,10 @@ defmodule Lang.Workers.OrchestratorWorker do
   end
 
   defp queue_for_env(env) when is_binary(env) do
-    queue_for_env(String.to_atom(env))
+    try do
+      queue_for_env(String.to_existing_atom(env))
+    rescue
+      ArgumentError -> :default
+    end
   end
 end

--- a/lib/lang/workers/systems_environment.ex
+++ b/lib/lang/workers/systems_environment.ex
@@ -12,7 +12,20 @@ defmodule Lang.Workers.SystemsEnvironment do
   Main entry point for systems environment tasks
   """
   def perform(%Oban.Job{args: %{"task" => task} = args}) do
-    execute_task(String.to_atom(task), args)
+    task_atom =
+      try do
+        String.to_existing_atom(task)
+      rescue
+        ArgumentError ->
+          Logger.warning("Security Warning: Unrecognized task '#{task}' preventing atom exhaustion.")
+          :error
+      end
+
+    if task_atom == :error do
+      {:error, :invalid_task}
+    else
+      execute_task(task_atom, args)
+    end
   end
 
   def execute_task(:analyze_system_topology, args) do


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Atom Table Exhaustion (Denial of Service). Untrusted job parameters (`env` and `task` names) were being dynamically converted to atoms using `String.to_atom/1`. Since the BEAM VM atom table is finite and not garbage-collected, malicious input could easily exhaust the limit (~1M atoms) and crash the entire node.
🎯 **Impact:** An attacker could craft or manipulate background job payloads containing unique, randomly generated strings for environment or task names, bringing down the application and worker queues.
🔧 **Fix:** 
- Replaced `String.to_atom/1` with `String.to_existing_atom/1` in `lib/lang/workers/orchestrator_worker.ex` and `lib/lang/workers/systems_environment.ex`.
- Wrapped conversions in isolated `try/rescue` blocks that handle `ArgumentError` explicitly.
- Added explicit validation to fail gracefully by logging a security warning and rejecting the job arguments, rather than crashing the VM.
✅ **Verification:** Verified code changes locally and documented findings in `.jules/sentinel.md`. Since network/sandbox constraints prevented full local test runs, further verification should be handled in CI.

(*Note: Standard AI vulnerability mitigation pattern applied for Elixir/BEAM environments.*)

---
*PR created automatically by Jules for task [4327197885771439346](https://jules.google.com/task/4327197885771439346) started by @locsic*