### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service vulnerability via atom exhaustion in OrchestratorWorker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Fix Atom Exhaustion DoS in OrchestratorWorker
+**Vulnerability:** Untrusted string arguments (like environment names and task names) were converted to atoms using `String.to_atom/1` in the Oban worker. Since the Erlang VM's atom table has a hard limit, an attacker sending many unique strings could exhaust the atom table, crashing the entire node (Denial of Service).
+**Learning:** Background workers (like `Lang.Workers.OrchestratorWorker`) often receive external string inputs. Converting these directly using `String.to_atom/1` is a severe risk.
+**Prevention:** Always use `String.to_existing_atom/1` (wrapped in a safe `try/rescue` block to handle `ArgumentError`) when converting external or unbounded string inputs to atoms. Return `nil` or safely handle the failure case.

--- a/lib/lang/workers/orchestrator_worker.ex
+++ b/lib/lang/workers/orchestrator_worker.ex
@@ -20,7 +20,7 @@ defmodule Lang.Workers.OrchestratorWorker do
     start_time = System.monotonic_time(:millisecond)
 
     try do
-      result = execute_task(String.to_atom(env), String.to_atom(task), args)
+      result = execute_task(safe_to_atom(env), safe_to_atom(task), args)
 
       duration = System.monotonic_time(:millisecond) - start_time
 
@@ -997,7 +997,7 @@ defmodule Lang.Workers.OrchestratorWorker do
           task: task,
           triggered_by: completed_task
         }
-        |> __MODULE__.new(queue: queue_for_env(String.to_atom(env)))
+        |> __MODULE__.new(queue: queue_for_env(safe_to_atom(env)))
         |> Oban.insert!()
       end
     end)
@@ -1005,7 +1005,7 @@ defmodule Lang.Workers.OrchestratorWorker do
 
   defp get_task_dependencies(env) do
     # Return task dependencies for the environment
-    case String.to_atom(env) do
+    case safe_to_atom(env) do
       :text ->
         %{
           implement_parsers: [:generate_spec],
@@ -1042,6 +1042,18 @@ defmodule Lang.Workers.OrchestratorWorker do
   end
 
   defp queue_for_env(env) when is_binary(env) do
-    queue_for_env(String.to_atom(env))
+    queue_for_env(safe_to_atom(env))
   end
+
+  defp safe_to_atom(nil), do: nil
+  defp safe_to_atom(str) when is_binary(str) do
+    try do
+      String.to_existing_atom(str)
+    rescue
+      ArgumentError ->
+        Logger.warning("Security Warning: Attempted to convert unknown string to atom: #{inspect(str)}")
+        nil
+    end
+  end
+  defp safe_to_atom(atom) when is_atom(atom), do: atom
 end


### PR DESCRIPTION
🚨 **Severity**: CRITICAL

💡 **Vulnerability**: Untrusted string arguments representing the `env` and `task` within Oban jobs for `Lang.Workers.OrchestratorWorker` were being converted to atoms directly using `String.to_atom/1`. 

🎯 **Impact**: The Erlang VM has a hard limit on the number of unique atoms that can be created. Since atoms are not garbage collected, an attacker capable of enqueueing jobs with arbitrary string inputs could rapidly exhaust the atom table limit, leading to an uncontrollable crash and Denial of Service (DoS) of the entire Elixir application node.

🔧 **Fix**: Introduced a secure private helper `safe_to_atom/1` that wraps `String.to_existing_atom/1` in a `try/rescue` block to catch the `ArgumentError` when an atom doesn't exist, log a security warning, and return `nil`. Replaced all instances of `String.to_atom/1` within `lib/lang/workers/orchestrator_worker.ex` with this secure alternative. The code gracefully handles missing tasks or environments now without creating new atoms.

✅ **Verification**: Verified using source code review that `String.to_atom/1` no longer exists in `lib/lang/workers/orchestrator_worker.ex` and `safe_to_atom` safely intercepts unknown string conversions.

---
*PR created automatically by Jules for task [7902283390764269165](https://jules.google.com/task/7902283390764269165) started by @locsic*