### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Atom Table Exhaustion DoS in Workers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-20 - Prevent Atom Table Exhaustion DoS in Workers
+**Vulnerability:** Converting unsanitized user inputs or job arguments to atoms using `String.to_atom/1` can lead to atom table exhaustion Denial of Service (DoS) attacks, as atoms are not garbage collected in Elixir.
+**Learning:** `Oban.Job` arguments or incoming API payloads that are strings should never be dynamically converted to atoms without checks, as malicious payloads with uniquely generated strings could crash the node.
+**Prevention:** Always use `String.to_existing_atom/1` when converting dynamic strings to atoms. Wrap the call in a `try/rescue` block targeting `ArgumentError` to safely catch invalid values, log a security warning, and gracefully fallback to a safe default value.

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -120,7 +120,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = parse_period_type(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -143,7 +143,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = parse_period_type(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -189,7 +189,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = parse_period_type(args["period_type"] || "daily")
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")
@@ -542,4 +542,16 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
     end_dt = DateTime.new!(end_date, ~T[23:59:59], "Etc/UTC")
     {start_dt, end_dt}
   end
+
+  defp parse_period_type(period) when is_binary(period) do
+    try do
+      String.to_existing_atom(period)
+    rescue
+      ArgumentError ->
+        Logger.warning("Security Warning: Attempted atom exhaustion via period_type: #{inspect(period)}")
+        :daily
+    end
+  end
+
+  defp parse_period_type(period) when is_atom(period), do: period
 end


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Atom table exhaustion DoS. The `ProductivityMetricsWorker` dynamically converts the `period_type` field from the Oban job argument map into an atom using `String.to_atom/1`. Since atoms are not garbage collected in Elixir/Erlang, a malicious payload creating uniquely generated strings for `period_type` could rapidly fill the atom table limit (by default 1,048,576 atoms), causing the entire Erlang VM node to crash.
🎯 Impact: Exploiting this allows an attacker to repeatedly crash backend worker nodes and potentially any web node enqueueing the job if `String.to_atom` was used there as well, leading to widespread Denial of Service.
🔧 Fix: Replaced `String.to_atom/1` with a safe parsing helper `parse_period_type/1` that strictly uses `String.to_existing_atom/1`. This is wrapped in a tight `try/rescue` block targeting `ArgumentError` so that any invalid payload is ignored, a security warning is logged, and a safe default fallback (`:daily`) is used.
✅ Verification: Ensured code properly compiles and tests pass (when available), and verified the file diff. Created a new entry in `.jules/sentinel.md` documenting the pattern.

---
*PR created automatically by Jules for task [13464207996555451437](https://jules.google.com/task/13464207996555451437) started by @locsic*