### PR TITLE
feat: loci/claude — Haiku stigmergy via Loci cave storage

### DIFF
--- a/loci/claude/claude.mbt
+++ b/loci/claude/claude.mbt
@@ -1,0 +1,569 @@
+///|
+/// loci/claude — Haiku stigmergy via Loci cave storage.
+///
+/// Implements indirect coordination (stigmergy) for Claude model tiers.
+/// Haiku scouts run freely and deposit Residue into the Loci cave partition.
+/// Sonnet/Opus orchestrators read emergent attention patterns from loci.
+///
+/// The Loci partition is the shared substrate — gated at AiModelSessionSemantic
+/// depth, making it the richest semantic layer in the cave hierarchy.
+///
+/// Key namespace in the Loci partition:
+///   "s:<anchor>"   → StigmaEntry bytes (cumulative weight for this anchor)
+///   "m:<scout_id>" → MulspState bytes (scout identity snapshot)
+///
+/// Stigmergy cycle:
+///   spawn_haiku → scout.observe(anchor, weight) → deposit to loci
+///   → orchestrator.hot_anchors() → directs next delegation round
+
+// ---------------------------------------------------------------------------
+// StigmaEntry — cumulative anchor attention record
+// ---------------------------------------------------------------------------
+
+///|
+let stigma_magic : Array[Byte] = [b'\x53', b'\x54', b'\x45', b'\x01'] // "STE\x01"
+
+///|
+/// Cumulative attention record for one anchor in the Loci partition.
+/// Updated each time a Haiku scout deposits a Residue for this anchor.
+pub(all) struct StigmaEntry {
+  anchor : String
+  total_weight : Int
+  contributor_count : Int
+  last_epoch : Int
+  last_timestamp : Int
+} derive(Debug)
+
+///|
+/// Create a fresh StigmaEntry from the first deposit for this anchor.
+pub fn StigmaEntry::fresh(
+  anchor : String,
+  weight : Int,
+  epoch : Int,
+  timestamp : Int,
+) -> StigmaEntry {
+  {
+    anchor,
+    total_weight: weight,
+    contributor_count: 1,
+    last_epoch: epoch,
+    last_timestamp: timestamp,
+  }
+}
+
+///|
+/// Accumulate another observation into this entry.
+pub fn StigmaEntry::accrete(
+  self : StigmaEntry,
+  weight : Int,
+  epoch : Int,
+  timestamp : Int,
+) -> StigmaEntry {
+  {
+    ..self,
+    total_weight: self.total_weight + weight,
+    contributor_count: self.contributor_count + 1,
+    last_epoch: if epoch > self.last_epoch { epoch } else { self.last_epoch },
+    last_timestamp: if timestamp > self.last_timestamp {
+      timestamp
+    } else {
+      self.last_timestamp
+    },
+  }
+}
+
+///|
+pub fn StigmaEntry::to_bytes(self : StigmaEntry) -> Array[Byte] {
+  let buf : Array[Byte] = []
+  for b in stigma_magic {
+    buf.push(b)
+  }
+  stigma_write_u32(buf, self.total_weight)
+  stigma_write_u32(buf, self.contributor_count)
+  stigma_write_u32(buf, self.last_epoch)
+  stigma_write_u32(buf, self.last_timestamp)
+  stigma_write_str(buf, self.anchor)
+  buf
+}
+
+///|
+pub fn StigmaEntry::from_bytes(data : Array[Byte]) -> StigmaEntry? {
+  let len = data.length()
+  if len < 20 {
+    return None
+  }
+  if data[0] != stigma_magic[0] ||
+    data[1] != stigma_magic[1] ||
+    data[2] != stigma_magic[2] ||
+    data[3] != stigma_magic[3] {
+    return None
+  }
+  let total_weight = stigma_read_u32(data, 4)
+  let contributor_count = stigma_read_u32(data, 8)
+  let last_epoch = stigma_read_u32(data, 12)
+  let last_timestamp = stigma_read_u32(data, 16)
+  let anchor = match stigma_read_str(data, 20, len) {
+    Some((s, _)) => s
+    None => return None
+  }
+  Some({ anchor, total_weight, contributor_count, last_epoch, last_timestamp })
+}
+
+// ---------------------------------------------------------------------------
+// LociStigmergy — cave-backed stigmergy board
+// ---------------------------------------------------------------------------
+
+///|
+/// Stigmergy board backed by the Loci cave partition.
+///
+/// Shared between orchestrators and scouts via the CaveStore array reference —
+/// all parties writing to the same underlying Loci cave see each other's deposits.
+pub(all) struct LociStigmergy {
+  cave : @cave.CaveStore
+  node_id : String
+  mut epoch : Int
+} derive(Debug)
+
+///|
+pub fn LociStigmergy::new(
+  cave : @cave.CaveStore,
+  node_id : String,
+) -> LociStigmergy {
+  { cave, node_id, epoch: 0 }
+}
+
+///|
+/// Deposit a Residue — merge its weight into the StigmaEntry for its anchor.
+pub fn LociStigmergy::deposit(
+  self : LociStigmergy,
+  residue : @emergent.Residue,
+) -> Unit {
+  self.epoch = self.epoch + 1
+  let key = "s:" + residue.anchor
+  let updated = match self.cave.loci_get(key) {
+    Some(bytes) =>
+      match StigmaEntry::from_bytes(bytes) {
+        Some(existing) =>
+          existing.accrete(residue.weight, residue.epoch, residue.timestamp)
+        None =>
+          StigmaEntry::fresh(
+            residue.anchor,
+            residue.weight,
+            residue.epoch,
+            residue.timestamp,
+          )
+      }
+    None =>
+      StigmaEntry::fresh(
+        residue.anchor,
+        residue.weight,
+        residue.epoch,
+        residue.timestamp,
+      )
+  }
+  let _ = self.cave.loci_put(key, updated.to_bytes())
+}
+
+///|
+/// Read the cumulative StigmaEntry for a specific anchor.
+pub fn LociStigmergy::read_anchor(
+  self : LociStigmergy,
+  anchor : String,
+) -> StigmaEntry? {
+  match self.cave.loci_get("s:" + anchor) {
+    Some(bytes) => StigmaEntry::from_bytes(bytes)
+    None => None
+  }
+}
+
+///|
+/// All anchors with stigma entries in loci.
+pub fn LociStigmergy::all_anchors(self : LociStigmergy) -> Array[String] {
+  let result : Array[String] = []
+  for key in self.cave.loci_keys() {
+    if is_stigma_key(key) {
+      result.push(strip_stigma_prefix(key))
+    }
+  }
+  result
+}
+
+///|
+/// Top-n anchors sorted by total_weight descending.
+pub fn LociStigmergy::top_anchors(
+  self : LociStigmergy,
+  n : Int,
+) -> Array[StigmaEntry] {
+  let entries : Array[StigmaEntry] = []
+  for key in self.cave.loci_keys() {
+    if is_stigma_key(key) {
+      match self.cave.loci_get(key) {
+        Some(bytes) =>
+          match StigmaEntry::from_bytes(bytes) {
+            Some(entry) => entries.push(entry)
+            None => ()
+          }
+        None => ()
+      }
+    }
+  }
+  // Insertion sort descending by total_weight
+  let mut i = 1
+  while i < entries.length() {
+    let cur = entries[i]
+    let mut j = i - 1
+    while j >= 0 && entries[j].total_weight < cur.total_weight {
+      entries[j + 1] = entries[j]
+      j = j - 1
+    }
+    entries[j + 1] = cur
+    i = i + 1
+  }
+  let top : Array[StigmaEntry] = []
+  let limit = if n < entries.length() { n } else { entries.length() }
+  let mut k = 0
+  while k < limit {
+    top.push(entries[k])
+    k = k + 1
+  }
+  top
+}
+
+// ---------------------------------------------------------------------------
+// HaikuScout — Haiku-tier agent
+// ---------------------------------------------------------------------------
+
+///|
+/// A Haiku-tier mulsp session that scouts and deposits residue into loci.
+/// Caller-owned — the orchestrator tracks scout IDs, scouts are held externally.
+pub(all) struct HaikuScout {
+  mut mulsp_state : @mulsp.MulspState
+  muyata : @muyata.MuyataProfile
+  stigmergy : LociStigmergy
+  mut seq : Int
+} derive(Debug)
+
+///|
+/// Observe an anchor — create a Residue and deposit it into the shared loci.
+/// Returns false if the scout is not in Active state.
+pub fn HaikuScout::observe(
+  self : HaikuScout,
+  anchor : String,
+  weight : Int,
+  now_ms : Int,
+) -> Bool {
+  if self.mulsp_state.lifecycle != @mulsp.Active {
+    return false
+  }
+  let residue = @emergent.Residue::new(
+    self.mulsp_state.mulsp_id,
+    self.seq,
+    anchor,
+    weight,
+    now_ms,
+  )
+  self.stigmergy.deposit(residue)
+  self.seq = self.seq + 1
+  // Record residue ref in scout's mulsp trail
+  self.mulsp_state = self.mulsp_state.emit_residue(
+    "r:" + anchor + ":" + self.seq.to_string(),
+  )
+  // Persist updated scout snapshot in loci
+  let _ = self.stigmergy.cave.loci_put(
+    "m:" + self.mulsp_state.mulsp_id,
+    self.mulsp_state.to_bytes(),
+  )
+  true
+}
+
+///|
+/// Quiesce this scout — Active/Delegated → Quiescent.
+pub fn HaikuScout::quiesce(self : HaikuScout) -> Bool {
+  match self.mulsp_state.quiesce() {
+    Some(q) => {
+      self.mulsp_state = q
+      let _ = self.stigmergy.cave.loci_put(
+        "m:" + q.mulsp_id,
+        q.to_bytes(),
+      )
+      true
+    }
+    None => false
+  }
+}
+
+///|
+pub fn HaikuScout::is_active(self : HaikuScout) -> Bool {
+  self.mulsp_state.lifecycle == @mulsp.Active
+}
+
+///|
+pub fn HaikuScout::scout_id(self : HaikuScout) -> String {
+  self.mulsp_state.mulsp_id
+}
+
+///|
+/// Number of residues this scout has deposited.
+pub fn HaikuScout::deposit_count(self : HaikuScout) -> Int {
+  self.seq
+}
+
+// ---------------------------------------------------------------------------
+// ClaudeOrchestrator — Sonnet/Opus-tier orchestrator
+// ---------------------------------------------------------------------------
+
+///|
+/// Sonnet/Opus-tier orchestrator that spawns Haiku scouts and reads stigmergy.
+///
+/// The orchestrator's mulsp cycles through delegation states as it spawns:
+///   Active → fork → Delegated → (quiesce→reattach→activate) → Active → fork → …
+///
+/// All scouts share the orchestrator's CaveStore reference, so every
+/// scout deposit is immediately visible to the orchestrator via hot_anchors().
+pub(all) struct ClaudeOrchestrator {
+  mut mulsp_state : @mulsp.MulspState
+  muyata : @muyata.MuyataProfile
+  stigmergy : LociStigmergy
+  scout_ids : Array[String]
+  mut scout_counter : Int
+} derive(Debug)
+
+///|
+/// Create an orchestrator. Requires an Active mulsp at Sonnet or Opus tier.
+pub fn ClaudeOrchestrator::new(
+  mulsp_state : @mulsp.MulspState,
+  muyata : @muyata.MuyataProfile,
+  cave : @cave.CaveStore,
+) -> ClaudeOrchestrator? {
+  if muyata.tier() == @muyata.Haiku {
+    return None
+  }
+  if mulsp_state.lifecycle != @mulsp.Active {
+    return None
+  }
+  Some({
+    mulsp_state,
+    muyata,
+    stigmergy: LociStigmergy::new(cave, mulsp_state.mulsp_id),
+    scout_ids: [],
+    scout_counter: 0,
+  })
+}
+
+///|
+/// Spawn a Haiku scout. Forks the parent mulsp and boots the child to Active.
+///
+/// If the orchestrator's mulsp is Delegated from a prior spawn, it automatically
+/// cycles Delegated → Quiescent → Attached → Active before forking again.
+pub fn ClaudeOrchestrator::spawn_haiku(
+  self : ClaudeOrchestrator,
+  intent : @muyata.WorkIntent,
+) -> HaikuScout? {
+  // Bring parent to Active, cycling through delegation if needed
+  let active_parent : @mulsp.MulspState = match self.mulsp_state.lifecycle {
+    @mulsp.Active => self.mulsp_state
+    @mulsp.Delegated =>
+      match self.mulsp_state.quiesce() {
+        Some(q) =>
+          match q.reattach() {
+            Some(r) =>
+              match r.activate() {
+                Some(a) => a
+                None => return None
+              }
+            None => return None
+          }
+        None => return None
+      }
+    _ => return None
+  }
+  let scout_id = active_parent.mulsp_id +
+    ":h:" +
+    self.scout_counter.to_string()
+  self.scout_counter = self.scout_counter + 1
+  // Fork: parent → Delegated, child → Dormant (with lineage)
+  let child_dormant : @mulsp.MulspState = match active_parent.fork(
+    scout_id,
+    None,
+  ) {
+    Some((new_parent, child)) => {
+      self.mulsp_state = new_parent
+      child
+    }
+    None => return None
+  }
+  // Inherit genius_loci and scope_root from parent
+  let genius = match active_parent.genius_loci {
+    Some(g) => g
+    None => "claude"
+  }
+  let scope = match active_parent.scope_root {
+    Some(s) => s
+    None => "."
+  }
+  // Boot child: Dormant → Attached → Active
+  let child_active : @mulsp.MulspState = match child_dormant.attach(
+    genius,
+    scope,
+  ) {
+    Some(attached) =>
+      match attached.activate() {
+        Some(active) => active
+        None => return None
+      }
+    None => return None
+  }
+  // Haiku muyata — cloned from orchestrator's profile, downscaled to Haiku
+  let haiku_muyata = self.muyata.clone_as(@muyata.Haiku, intent)
+  // Snapshot the new scout's identity in loci
+  let _ = self.stigmergy.cave.loci_put(
+    "m:" + scout_id,
+    child_active.to_bytes(),
+  )
+  self.scout_ids.push(scout_id)
+  Some({
+    mulsp_state: child_active,
+    muyata: haiku_muyata,
+    stigmergy: self.stigmergy,
+    seq: 0,
+  })
+}
+
+///|
+/// Top-n anchors by accumulated stigma weight — reads directly from loci.
+pub fn ClaudeOrchestrator::hot_anchors(
+  self : ClaudeOrchestrator,
+  n : Int,
+) -> Array[StigmaEntry] {
+  self.stigmergy.top_anchors(n)
+}
+
+///|
+/// Read the stigma for a specific anchor.
+pub fn ClaudeOrchestrator::read_anchor(
+  self : ClaudeOrchestrator,
+  anchor : String,
+) -> StigmaEntry? {
+  self.stigmergy.read_anchor(anchor)
+}
+
+///|
+/// Total number of scouts spawned (active and quiesced).
+pub fn ClaudeOrchestrator::total_scout_count(
+  self : ClaudeOrchestrator,
+) -> Int {
+  self.scout_ids.length()
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+///|
+fn is_stigma_key(key : String) -> Bool {
+  let len = key.length()
+  if len < 2 {
+    return false
+  }
+  let mut i = 0
+  let mut ok = false
+  for ch in key {
+    if i == 0 && ch != 's' {
+      break
+    }
+    if i == 1 {
+      ok = ch == ':'
+      break
+    }
+    i = i + 1
+  }
+  ok
+}
+
+///|
+fn strip_stigma_prefix(key : String) -> String {
+  let sb = StringBuilder::new()
+  let mut i = 0
+  for ch in key {
+    if i >= 2 {
+      sb.write_char(ch)
+    }
+    i = i + 1
+  }
+  sb.to_string()
+}
+
+///|
+fn stigma_write_u32(buf : Array[Byte], v : Int) -> Unit {
+  buf.push((v & 0xFF).to_byte())
+  buf.push(((v >> 8) & 0xFF).to_byte())
+  buf.push(((v >> 16) & 0xFF).to_byte())
+  buf.push(((v >> 24) & 0xFF).to_byte())
+}
+
+///|
+fn stigma_read_u32(data : Array[Byte], pos : Int) -> Int {
+  (data[pos].to_int() & 0xFF) |
+  ((data[pos + 1].to_int() & 0xFF) << 8) |
+  ((data[pos + 2].to_int() & 0xFF) << 16) |
+  ((data[pos + 3].to_int() & 0xFF) << 24)
+}
+
+///|
+fn stigma_write_str(buf : Array[Byte], s : String) -> Unit {
+  let encoded : Array[Byte] = []
+  for ch in s {
+    let cp = ch.to_int()
+    if cp < 0x80 {
+      encoded.push(cp.to_byte())
+    } else if cp < 0x800 {
+      encoded.push((0xC0 | (cp >> 6)).to_byte())
+      encoded.push((0x80 | (cp & 0x3F)).to_byte())
+    } else {
+      encoded.push((0xE0 | (cp >> 12)).to_byte())
+      encoded.push((0x80 | ((cp >> 6) & 0x3F)).to_byte())
+      encoded.push((0x80 | (cp & 0x3F)).to_byte())
+    }
+  }
+  stigma_write_u32(buf, encoded.length())
+  for b in encoded {
+    buf.push(b)
+  }
+}
+
+///|
+fn stigma_read_str(data : Array[Byte], pos : Int, len : Int) -> (String, Int)? {
+  if pos + 4 > len {
+    return None
+  }
+  let n = stigma_read_u32(data, pos)
+  let start = pos + 4
+  if start + n > len {
+    return None
+  }
+  let sb = StringBuilder::new()
+  let mut i = start
+  let end_pos = start + n
+  while i < end_pos {
+    let b0 = data[i].to_int()
+    if (b0 & 0x80) == 0 {
+      sb.write_char(b0.to_char().unwrap())
+      i = i + 1
+    } else if (b0 & 0xE0) == 0xC0 && i + 1 < end_pos {
+      let b1 = data[i + 1].to_int()
+      let cp = ((b0 & 0x1F) << 6) | (b1 & 0x3F)
+      sb.write_char(cp.to_char().unwrap())
+      i = i + 2
+    } else if (b0 & 0xF0) == 0xE0 && i + 2 < end_pos {
+      let b1 = data[i + 1].to_int()
+      let b2 = data[i + 2].to_int()
+      let cp = ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F)
+      sb.write_char(cp.to_char().unwrap())
+      i = i + 3
+    } else {
+      sb.write_char('\u{FFFD}')
+      i = i + 1
+    }
+  }
+  Some((sb.to_string(), end_pos))
+}

--- a/loci/claude/claude_test.mbt
+++ b/loci/claude/claude_test.mbt
@@ -1,0 +1,411 @@
+///|
+/// Tests for loci/claude — Haiku stigmergy via Loci cave storage.
+
+// ---------------------------------------------------------------------------
+// StigmaEntry serialization
+// ---------------------------------------------------------------------------
+
+///|
+test "stigma entry round-trip" {
+  let entry = @claude.StigmaEntry::fresh("cave/store", 12, 3, 5000)
+  let bytes = entry.to_bytes()
+  let restored = @claude.StigmaEntry::from_bytes(bytes)
+  assert_true(restored is Some(_))
+  let r = restored.unwrap()
+  assert_eq(r.anchor, "cave/store")
+  assert_eq(r.total_weight, 12)
+  assert_eq(r.contributor_count, 1)
+  assert_eq(r.last_epoch, 3)
+  assert_eq(r.last_timestamp, 5000)
+}
+
+///|
+test "stigma entry accrete accumulates weight" {
+  let entry = @claude.StigmaEntry::fresh("mulsp/lifecycle", 10, 1, 100)
+  let entry2 = entry.accrete(5, 2, 200)
+  let entry3 = entry2.accrete(8, 1, 300)
+  assert_eq(entry3.total_weight, 23)
+  assert_eq(entry3.contributor_count, 3)
+  assert_eq(entry3.last_epoch, 2)
+  assert_eq(entry3.last_timestamp, 300)
+}
+
+///|
+test "stigma entry from_bytes rejects bad magic" {
+  let bad : Array[Byte] = [b'\x00', b'\x00', b'\x00', b'\x00', b'\x00', b'\x00',
+    b'\x00', b'\x00', b'\x00', b'\x00', b'\x00', b'\x00', b'\x00', b'\x00',
+    b'\x00', b'\x00', b'\x00', b'\x00', b'\x00', b'\x00']
+  assert_true(@claude.StigmaEntry::from_bytes(bad) is None)
+}
+
+///|
+test "stigma entry from_bytes rejects too-short data" {
+  assert_true(@claude.StigmaEntry::from_bytes([]) is None)
+  assert_true(@claude.StigmaEntry::from_bytes([b'\x53', b'\x54', b'\x45']) is None)
+}
+
+// ---------------------------------------------------------------------------
+// LociStigmergy
+// ---------------------------------------------------------------------------
+
+///|
+test "loci stigmergy deposit and read_anchor" {
+  let cave = @cave.CaveStore::standard()
+  let stigmergy = @claude.LociStigmergy::new(cave, "node-1")
+  let r1 = @emergent.Residue::new("node-1", 0, "yata/void", 10, 1000)
+  stigmergy.deposit(r1)
+  let entry = stigmergy.read_anchor("yata/void")
+  assert_true(entry is Some(_))
+  let e = entry.unwrap()
+  assert_eq(e.anchor, "yata/void")
+  assert_eq(e.total_weight, 10)
+  assert_eq(e.contributor_count, 1)
+}
+
+///|
+test "loci stigmergy merges multiple deposits for same anchor" {
+  let cave = @cave.CaveStore::standard()
+  let stigmergy = @claude.LociStigmergy::new(cave, "node-1")
+  stigmergy.deposit(@emergent.Residue::new("n1", 0, "mulsp", 5, 100))
+  stigmergy.deposit(@emergent.Residue::new("n2", 1, "mulsp", 7, 200))
+  stigmergy.deposit(@emergent.Residue::new("n1", 2, "mulsp", 3, 300))
+  let entry = stigmergy.read_anchor("mulsp").unwrap()
+  assert_eq(entry.total_weight, 15)
+  assert_eq(entry.contributor_count, 3)
+  assert_eq(entry.last_timestamp, 300)
+}
+
+///|
+test "loci stigmergy all_anchors lists deposited anchors" {
+  let cave = @cave.CaveStore::standard()
+  let stigmergy = @claude.LociStigmergy::new(cave, "node-1")
+  stigmergy.deposit(@emergent.Residue::new("n", 0, "alpha", 1, 0))
+  stigmergy.deposit(@emergent.Residue::new("n", 1, "beta", 2, 0))
+  stigmergy.deposit(@emergent.Residue::new("n", 2, "gamma", 3, 0))
+  let anchors = stigmergy.all_anchors()
+  assert_eq(anchors.length(), 3)
+}
+
+///|
+test "loci stigmergy top_anchors sorts by weight descending" {
+  let cave = @cave.CaveStore::standard()
+  let stigmergy = @claude.LociStigmergy::new(cave, "node-1")
+  stigmergy.deposit(@emergent.Residue::new("n", 0, "low", 2, 0))
+  stigmergy.deposit(@emergent.Residue::new("n", 1, "high", 20, 0))
+  stigmergy.deposit(@emergent.Residue::new("n", 2, "mid", 10, 0))
+  let top = stigmergy.top_anchors(3)
+  assert_eq(top.length(), 3)
+  assert_eq(top[0].anchor, "high")
+  assert_eq(top[1].anchor, "mid")
+  assert_eq(top[2].anchor, "low")
+}
+
+///|
+test "loci stigmergy top_anchors respects n limit" {
+  let cave = @cave.CaveStore::standard()
+  let stigmergy = @claude.LociStigmergy::new(cave, "node-1")
+  stigmergy.deposit(@emergent.Residue::new("n", 0, "a1", 5, 0))
+  stigmergy.deposit(@emergent.Residue::new("n", 1, "a2", 3, 0))
+  stigmergy.deposit(@emergent.Residue::new("n", 2, "a3", 1, 0))
+  let top = stigmergy.top_anchors(2)
+  assert_eq(top.length(), 2)
+  assert_eq(top[0].anchor, "a1")
+  assert_eq(top[1].anchor, "a2")
+}
+
+// ---------------------------------------------------------------------------
+// ClaudeOrchestrator construction
+// ---------------------------------------------------------------------------
+
+///|
+test "orchestrator rejects haiku tier" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("h-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Haiku,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  assert_true(@claude.ClaudeOrchestrator::new(mulsp3, muyata, cave) is None)
+}
+
+///|
+test "orchestrator rejects non-active mulsp" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("s-1", "claude", "wasm-gc", "emergent")
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Sonnet,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  assert_true(@claude.ClaudeOrchestrator::new(mulsp, muyata, cave) is None)
+}
+
+///|
+test "orchestrator accepts sonnet tier" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("s-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Sonnet,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  let orch = @claude.ClaudeOrchestrator::new(mulsp3, muyata, cave)
+  assert_true(orch is Some(_))
+}
+
+///|
+test "orchestrator accepts opus tier" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("o-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Opus,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  let orch = @claude.ClaudeOrchestrator::new(mulsp3, muyata, cave)
+  assert_true(orch is Some(_))
+}
+
+// ---------------------------------------------------------------------------
+// Spawning Haiku scouts
+// ---------------------------------------------------------------------------
+
+///|
+test "orchestrator spawns haiku scout" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("s-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Sonnet,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  let orch = @claude.ClaudeOrchestrator::new(mulsp3, muyata, cave).unwrap()
+  let scout = orch.spawn_haiku(@muyata.Observation)
+  assert_true(scout is Some(_))
+  let s = scout.unwrap()
+  assert_true(s.is_active())
+  assert_true(s.muyata.is_scout())
+  assert_eq(orch.total_scout_count(), 1)
+}
+
+///|
+test "haiku scout is child of orchestrator mulsp" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("s-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Sonnet,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  let orch = @claude.ClaudeOrchestrator::new(mulsp3, muyata, cave).unwrap()
+  let scout = orch.spawn_haiku(@muyata.Observation).unwrap()
+  // Scout ID contains orchestrator's mulsp_id as prefix
+  assert_true(scout.scout_id().length() > 0)
+  // Scout snapshot is in loci
+  let keys = cave.loci_keys()
+  let mut found = false
+  for k in keys {
+    if k == "m:" + scout.scout_id() {
+      found = true
+    }
+  }
+  assert_true(found)
+}
+
+///|
+test "orchestrator can spawn multiple scouts" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("s-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Sonnet,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  let orch = @claude.ClaudeOrchestrator::new(mulsp3, muyata, cave).unwrap()
+  let s1 = orch.spawn_haiku(@muyata.Observation)
+  let s2 = orch.spawn_haiku(@muyata.GrammarInfer)
+  let s3 = orch.spawn_haiku(@muyata.Audit)
+  assert_true(s1 is Some(_))
+  assert_true(s2 is Some(_))
+  assert_true(s3 is Some(_))
+  assert_eq(orch.total_scout_count(), 3)
+}
+
+// ---------------------------------------------------------------------------
+// Stigmergy through observe → hot_anchors
+// ---------------------------------------------------------------------------
+
+///|
+test "scout deposits to loci orchestrator reads hot anchors" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("s-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Sonnet,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  let orch = @claude.ClaudeOrchestrator::new(mulsp3, muyata, cave).unwrap()
+  let mut scout = orch.spawn_haiku(@muyata.Observation).unwrap()
+  assert_true(scout.observe("cave/storage", 10, 1000))
+  assert_true(scout.observe("cave/storage", 5, 2000))
+  assert_true(scout.observe("mulsp/lifecycle", 8, 3000))
+  let anchors = orch.hot_anchors(2)
+  assert_eq(anchors.length(), 2)
+  assert_eq(anchors[0].anchor, "cave/storage")
+  assert_eq(anchors[0].total_weight, 15)
+  assert_eq(anchors[0].contributor_count, 2)
+  assert_eq(anchors[1].anchor, "mulsp/lifecycle")
+  assert_eq(anchors[1].total_weight, 8)
+}
+
+///|
+test "multiple scouts converge on same anchor" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("o-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Opus,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  let orch = @claude.ClaudeOrchestrator::new(mulsp3, muyata, cave).unwrap()
+  let mut s1 = orch.spawn_haiku(@muyata.Observation).unwrap()
+  let mut s2 = orch.spawn_haiku(@muyata.Observation).unwrap()
+  let mut s3 = orch.spawn_haiku(@muyata.GrammarInfer).unwrap()
+  // All three converge on "loci/partition"
+  let _ = s1.observe("loci/partition", 6, 100)
+  let _ = s2.observe("loci/partition", 4, 200)
+  let _ = s3.observe("loci/partition", 9, 300)
+  // s1 and s2 also notice "muyata/tier"
+  let _ = s1.observe("muyata/tier", 3, 150)
+  let _ = s2.observe("muyata/tier", 3, 250)
+  let top = orch.hot_anchors(2)
+  assert_eq(top[0].anchor, "loci/partition")
+  assert_eq(top[0].total_weight, 19)
+  assert_eq(top[0].contributor_count, 3)
+  assert_eq(top[1].anchor, "muyata/tier")
+  assert_eq(top[1].total_weight, 6)
+}
+
+///|
+test "scout observe fails when not active" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("s-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Sonnet,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  let orch = @claude.ClaudeOrchestrator::new(mulsp3, muyata, cave).unwrap()
+  let mut scout = orch.spawn_haiku(@muyata.Observation).unwrap()
+  // Quiesce the scout
+  assert_true(scout.quiesce())
+  assert_eq(scout.is_active(), false)
+  // Observe should fail
+  assert_eq(scout.observe("anything", 5, 1000), false)
+}
+
+// ---------------------------------------------------------------------------
+// Scout quiescence
+// ---------------------------------------------------------------------------
+
+///|
+test "scout quiesces cleanly" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("s-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Sonnet,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  let orch = @claude.ClaudeOrchestrator::new(mulsp3, muyata, cave).unwrap()
+  let mut scout = orch.spawn_haiku(@muyata.Observation).unwrap()
+  let _ = scout.observe("node/kernel", 5, 500)
+  assert_true(scout.is_active())
+  assert_true(scout.quiesce())
+  assert_eq(scout.is_active(), false)
+  // Loci retains the quiesced state snapshot
+  let snap = cave.loci_get("m:" + scout.scout_id())
+  assert_true(snap is Some(_))
+}
+
+///|
+test "deposit count tracks observations" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("s-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Sonnet,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  let orch = @claude.ClaudeOrchestrator::new(mulsp3, muyata, cave).unwrap()
+  let mut scout = orch.spawn_haiku(@muyata.Observation).unwrap()
+  assert_eq(scout.deposit_count(), 0)
+  let _ = scout.observe("a", 1, 0)
+  let _ = scout.observe("b", 2, 0)
+  let _ = scout.observe("a", 3, 0)
+  assert_eq(scout.deposit_count(), 3)
+}
+
+// ---------------------------------------------------------------------------
+// Loci persistence — stigmergy survives independently of in-memory state
+// ---------------------------------------------------------------------------
+
+///|
+test "loci cave retains stigma after scout quiesces" {
+  let cave = @cave.CaveStore::standard()
+  let mulsp = @mulsp.MulspState::new("s-1", "claude", "wasm-gc", "emergent")
+  let mulsp2 = mulsp.attach("claude", "/").unwrap()
+  let mulsp3 = mulsp2.activate().unwrap()
+  let muyata = @muyata.MuyataProfile::claude(
+    @muyata.Sonnet,
+    @muyata.Delegation,
+    "wasm-gc",
+    "emergent",
+  )
+  let orch = @claude.ClaudeOrchestrator::new(mulsp3, muyata, cave).unwrap()
+  let mut scout = orch.spawn_haiku(@muyata.Observation).unwrap()
+  let _ = scout.observe("spore/mobile-agent", 12, 1000)
+  let _ = scout.observe("spore/mobile-agent", 8, 2000)
+  let _ = scout.quiesce()
+  // The orchestrator can still read the stigma from loci
+  let entry = orch.read_anchor("spore/mobile-agent")
+  assert_true(entry is Some(_))
+  let e = entry.unwrap()
+  assert_eq(e.total_weight, 20)
+  assert_eq(e.contributor_count, 2)
+}

--- a/loci/claude/moon.pkg
+++ b/loci/claude/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "zpc/lang/cave",
+  "zpc/lang/mulsp",
+  "zpc/lang/muyata",
+  "zpc/lang/emergent",
+}

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -27,6 +27,7 @@
     "gopher",
     "net",
     "crypto",
-    "codex"
+    "codex",
+    "loci/claude"
   ]
 }


### PR DESCRIPTION
## Summary

- Introduces `loci/claude` — the first package under the new `loci/` namespace, wiring mulsp + Haiku stigmergy together using the Loci cave partition as the shared filesystem
- Sonnet/Opus orchestrators fork Haiku scouts whose observations accumulate as `StigmaEntry` records in the Loci cave; orchestrators read `hot_anchors()` back to route attention
- The `CaveStore` array reference is the shared medium — no direct channels between tiers, only stigmergy through loci writes

**Key types:**
- `StigmaEntry` — serialisable cumulative attention record per anchor (`"s:<anchor>"` key in Loci)
- `LociStigmergy` — cave-backed board; shared across scouts via the `CaveStore` heap array reference
- `HaikuScout` — caller-owned Haiku-tier agent; `observe(anchor, weight, now_ms)` deposits a `Residue`, `quiesce()` seals the session and persists state to loci
- `ClaudeOrchestrator` — Sonnet/Opus only; `spawn_haiku(intent)` forks a child mulsp and boots it to Active, cycling through the `Delegated → Quiescent → Attached → Active` arc for each additional spawn

**Loci key namespace:**
```
"s:<anchor>"   → StigmaEntry (cumulative weight, contributor count, epoch, timestamp)
"m:<scout_id>" → MulspState bytes (scout identity snapshot, updated on each observe/quiesce)
```

## Test plan

- [ ] `StigmaEntry` round-trip serialisation + accretion logic
- [ ] `LociStigmergy` deposit/read_anchor/all_anchors/top_anchors (sorting, n-limit)
- [ ] `ClaudeOrchestrator` construction guards (Haiku tier rejected, non-Active mulsp rejected)
- [ ] Spawning single + multiple Haiku scouts with correct lineage
- [ ] Scout observations visible to orchestrator via `hot_anchors()`
- [ ] Multiple scouts converging on the same anchor — weight accumulates correctly
- [ ] Scout quiesce — state persisted in loci, further `observe` calls fail cleanly
- [ ] Loci retains stigma after scout quiesces (persistence independence)

https://claude.ai/code/session_01Aa3nKexZ3eBx2JjFg3xDxU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aa3nKexZ3eBx2JjFg3xDxU)_