### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Atom exhaustion vulnerability in OrchestratorWorker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-28 - Atom Exhaustion DoS Mitigation
+**Vulnerability:** Unbounded conversion of user-controlled strings (like job arguments) to atoms using `String.to_atom/1` can exhaust the BEAM atom table and crash the application.
+**Learning:** Always use `String.to_existing_atom/1` when converting external input to atoms, as it only succeeds if the atom already exists in the system.
+**Prevention:** Use `String.to_existing_atom/1` and handle potential `ArgumentError` gracefully to prevent DoS attacks via atom exhaustion.

--- a/lib/lang/workers/orchestrator_worker.ex
+++ b/lib/lang/workers/orchestrator_worker.ex
@@ -20,7 +20,7 @@ defmodule Lang.Workers.OrchestratorWorker do
     start_time = System.monotonic_time(:millisecond)
 
     try do
-      result = execute_task(String.to_atom(env), String.to_atom(task), args)
+      result = execute_task(String.to_existing_atom(env), String.to_existing_atom(task), args)
 
       duration = System.monotonic_time(:millisecond) - start_time
 
@@ -41,6 +41,10 @@ defmodule Lang.Workers.OrchestratorWorker do
 
       :ok
     rescue
+      error in ArgumentError ->
+        Logger.warning("Security Warning: Attempted atom table exhaustion with invalid env or task: #{env}, #{task}. Error: #{inspect(error)}")
+        Master.notify_job_failed(args["job_id"], error)
+        {:error, "Invalid environment or task provided"}
       error ->
         Logger.error("Failed to execute #{task} for #{env}: #{inspect(error)}")
         Master.notify_job_failed(args["job_id"], error)
@@ -997,15 +1001,19 @@ defmodule Lang.Workers.OrchestratorWorker do
           task: task,
           triggered_by: completed_task
         }
-        |> __MODULE__.new(queue: queue_for_env(String.to_atom(env)))
+        |> __MODULE__.new(queue: queue_for_env(String.to_existing_atom(env)))
         |> Oban.insert!()
       end
     end)
+  rescue
+    ArgumentError ->
+      Logger.warning("Security Warning: Invalid environment provided to trigger_dependent_tasks: #{env}")
+      :ok
   end
 
   defp get_task_dependencies(env) do
     # Return task dependencies for the environment
-    case String.to_atom(env) do
+    case String.to_existing_atom(env) do
       :text ->
         %{
           implement_parsers: [:generate_spec],
@@ -1042,6 +1050,8 @@ defmodule Lang.Workers.OrchestratorWorker do
   end
 
   defp queue_for_env(env) when is_binary(env) do
-    queue_for_env(String.to_atom(env))
+    queue_for_env(String.to_existing_atom(env))
+  rescue
+    ArgumentError -> :default
   end
 end


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Atom exhaustion DoS. Unbounded conversion of user-controlled strings (like job arguments) to atoms using `String.to_atom/1` can exhaust the BEAM atom table and crash the application.
🎯 **Impact:** Malicious user inputs can exhaust atom table, crashing the application.
🔧 **Fix:** Use `String.to_existing_atom/1` and handle potential `ArgumentError` gracefully to prevent DoS attacks via atom exhaustion.
✅ **Verification:** Verified by manual code review and test suite execution.

---
*PR created automatically by Jules for task [14010197009864639064](https://jules.google.com/task/14010197009864639064) started by @locsic*