### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability via atom exhaustion in worker args

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-03 - Denial of Service via Atom Exhaustion in Worker Arguments
+**Vulnerability:** Untrusted string input from `Oban.Job` args (`args["period_type"]`) was passed directly to `String.to_atom/1` in `Lang.Workers.ProductivityMetricsWorker`.
+**Learning:** `String.to_atom/1` does not garbage collect the atoms it creates. Converting arbitrary or untrusted user input directly to atoms can exhaust the Erlang VM's atom table limit (default 1,048,576), crashing the entire node.
+**Prevention:** Always use `String.to_existing_atom/1` for untrusted input. Catch the `ArgumentError` in an isolated `try/rescue` block to handle invalid inputs safely without crashing the node.

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -120,7 +120,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -143,7 +143,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = safe_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -189,7 +189,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")
@@ -281,7 +281,21 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
     end
   end
 
+
   # Helper functions for metric calculations
+
+  defp safe_period_type(nil), do: :daily
+  defp safe_period_type(period) when is_binary(period) do
+    try do
+      String.to_existing_atom(period)
+    rescue
+      ArgumentError ->
+        Logger.warning("Security Warning: Attempted atom exhaustion with period_type: #{inspect(period)}")
+        :daily
+    end
+  end
+  defp safe_period_type(period) when is_atom(period), do: period
+
 
   defp update_user_productivity_metrics(user_id, period_type, date) do
     {period_start, period_end} = get_period_bounds(period_type, date)


### PR DESCRIPTION
This PR fixes a critical Denial of Service vulnerability caused by atom exhaustion in the ProductivityMetricsWorker.

🚨 Severity: HIGH
💡 Vulnerability: Untrusted input from Oban job arguments (`args["period_type"]`) was passed directly to `String.to_atom/1`. Since Erlang atoms are not garbage collected, an attacker or bad data could exhaust the VM's atom table limit (default 1,048,576), crashing the entire node.
🎯 Impact: Denial of Service (Node Crash)
🔧 Fix: Replaced `String.to_atom/1` with a safe helper that uses `String.to_existing_atom/1` wrapped in an isolated `try/rescue` block. It catches `ArgumentError`, logs a security warning, and gracefully falls back to `:daily`.
✅ Verification: Code review to ensure `String.to_atom/1` is no longer used for dynamic period type casting in `lib/lang/workers/productivity_metrics_worker.ex`. Ensure tests continue to pass.

---
*PR created automatically by Jules for task [7664510034259393842](https://jules.google.com/task/7664510034259393842) started by @locsic*