### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service (Atom Exhaustion)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-04 - Fix Denial of Service via Atom Exhaustion
+**Vulnerability:** Found `String.to_atom/1` used on untrusted string inputs (Oban job arguments) in `lib/lang/workers/productivity_metrics_worker.ex`. Because atoms in Erlang/Elixir are not garbage collected, this could allow an attacker to exhaust the atom table memory limits, causing a system crash (Denial of Service).
+**Learning:** Untrusted string input originating from job payloads was improperly converted to atoms instead of safely matching existing atoms.
+**Prevention:** Always use `String.to_existing_atom/1` wrapped in a `try/rescue` block to handle potential `ArgumentError` when dealing with dynamically generated or untrusted string inputs.

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -120,7 +120,15 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type =
+      try do
+        String.to_existing_atom(args["period_type"] || "daily")
+      rescue
+        ArgumentError ->
+          Logger.warning("Security Warning: Attempted to convert untrusted string to atom: #{inspect(args["period_type"])}")
+          :daily
+      end
+
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -143,7 +151,15 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type =
+      try do
+        String.to_existing_atom(args["period_type"] || "daily")
+      rescue
+        ArgumentError ->
+          Logger.warning("Security Warning: Attempted to convert untrusted string to atom: #{inspect(args["period_type"])}")
+          :daily
+      end
+
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -189,7 +205,15 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type =
+      try do
+        String.to_existing_atom(args["period_type"] || "daily")
+      rescue
+        ArgumentError ->
+          Logger.warning("Security Warning: Attempted to convert untrusted string to atom: #{inspect(args["period_type"])}")
+          :daily
+      end
+
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")


### PR DESCRIPTION
## 🚨 Severity
CRITICAL

## 💡 Vulnerability
The `ProductivityMetricsWorker` was using `String.to_atom/1` to convert the `period_type` job argument string directly to an atom. Since atoms are not garbage collected in Erlang/Elixir, dynamically converting untrusted input from job payloads to atoms can easily be abused by a bad actor to exhaust the BEAM virtual machine's atom table (limited to ~1M entries by default).

## 🎯 Impact
If exploited, the entire application node would crash immediately with an out-of-memory error (system limit), resulting in a full Denial of Service (DoS) for all users.

## 🔧 Fix
1. Swapped `String.to_atom/1` with `String.to_existing_atom/1` which only converts strings to atoms if the atom already exists in memory.
2. Wrapped the call in a `try/rescue` block to handle the `ArgumentError` that gets raised if an invalid atom string is passed.
3. Added a secure fallback to `:daily` and logged a descriptive security warning when invalid data is caught.

## ✅ Verification
1. Ensure the app compiles and the code block successfully catches unknown `period_type` strings without crashing the background worker.
2. The change is isolated to `lib/lang/workers/productivity_metrics_worker.ex`.

---
*PR created automatically by Jules for task [2718034909448363630](https://jules.google.com/task/2718034909448363630) started by @locsic*