### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Atom Exhaustion DoS in ProductivityMetricsWorker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Atom Table Exhaustion DoS Prevention
+**Vulnerability:** Untrusted Oban job arguments were being converted to atoms using `String.to_atom/1`, leading to a potential Denial of Service (DoS) vulnerability via atom table exhaustion.
+**Learning:** In Elixir/Erlang, dynamically created atoms are not garbage collected. Converting arbitrary user input or job arguments to atoms can crash the BEAM VM if the maximum atom limit is exceeded.
+**Prevention:** Always use `String.to_existing_atom/1` (and handle `ArgumentError`) or explicit string pattern matching when converting dynamic or untrusted strings to atoms.

--- a/lib/lang/workers/productivity_metrics_worker.ex
+++ b/lib/lang/workers/productivity_metrics_worker.ex
@@ -120,7 +120,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_user_metrics_update(args) do
     user_id = args["user_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Processing user metrics update for user #{user_id}, period: #{period_type}")
@@ -143,7 +143,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
   end
 
   defp handle_efficiency_report_generation(args) do
-    period_type = String.to_atom(args["period_type"])
+    period_type = safe_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
     organization_id = args["organization_id"]
 
@@ -189,7 +189,7 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
 
   defp handle_organization_aggregation(args) do
     organization_id = args["organization_id"]
-    period_type = String.to_atom(args["period_type"] || "daily")
+    period_type = safe_period_type(args["period_type"])
     date = Date.from_iso8601!(args["date"])
 
     Logger.info("Aggregating organization metrics for #{organization_id}")
@@ -278,6 +278,17 @@ defmodule Lang.Workers.ProductivityMetricsWorker do
       error ->
         Logger.error("Exception in bulk event processing: #{inspect(error)}")
         {:error, :processing_exception}
+    end
+  end
+
+  defp safe_period_type(nil), do: :daily
+  defp safe_period_type(val) when is_binary(val) do
+    try do
+      String.to_existing_atom(val)
+    rescue
+      ArgumentError ->
+        Logger.warning("Untrusted period_type input detected: #{inspect(val)}, falling back to :daily")
+        :daily
     end
   end
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unbounded atom creation via `String.to_atom/1` when parsing untrusted `period_type` job arguments.
🎯 **Impact:** Malicious actors could submit many jobs with uniquely crafted `period_type` strings, filling the Erlang VM's atom table and causing a catastrophic system-wide crash (Denial of Service).
🔧 **Fix:** Replaced `String.to_atom/1` with `String.to_existing_atom/1` wrapped in a `try/rescue` block to ensure only known atoms can be instantiated. If an unknown string is provided, a warning is logged, and it defaults to `:daily` to fail gracefully and securely.
✅ **Verification:** Verified by ensuring the code safely catches and logs `ArgumentError` when an arbitrary untrusted string is provided, preventing VM crashes. Code successfully passes compilation and static analysis for security issues.

---
*PR created automatically by Jules for task [15656046667493657077](https://jules.google.com/task/15656046667493657077) started by @locsic*