### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service (DoS) vulnerability via atom table exhaustion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - DoS via Atom Table Exhaustion
+**Vulnerability:** Untrusted user input was converted to atoms using `String.to_atom` in `lib/lang/workers/lsp_comparison_worker.ex`, potentially leading to Denial of Service (DoS) due to atom table exhaustion.
+**Learning:** `String.to_atom` creates atoms dynamically, and since atoms are not garbage collected in Erlang/Elixir, providing an unbounded amount of dynamic string inputs could cause the BEAM node to crash when the atom table limit is reached.
+**Prevention:** Always use `String.to_existing_atom` when dealing with user input. If an atom should exist but doesn't, it indicates an invalid input, and the resulting `ArgumentError` should be handled appropriately (e.g., returning an error or logging the incident).

--- a/lib/lang/workers/lsp_comparison_worker.ex
+++ b/lib/lang/workers/lsp_comparison_worker.ex
@@ -262,21 +262,33 @@ defmodule Lang.Workers.LSPComparisonWorker do
     {method, params} = convert_task_to_provider_request(task, context, lsp_enabled)
 
     # Execute via the agent variant
-    case apply(String.to_atom(agent_module), :handle_request, [method, params, []]) do
-      {:ok, result} ->
-        %{
-          status: :success,
-          output: result,
-          method: method,
-          lsp_context_used: lsp_enabled,
-          confidence: Map.get(result, :confidence, 0.0),
-          provider_metadata: Map.get(result, :metadata, %{})
-        }
+    try do
+      module_atom = String.to_existing_atom(agent_module)
+      case apply(module_atom, :handle_request, [method, params, []]) do
+        {:ok, result} ->
+          %{
+            status: :success,
+            output: result,
+            method: method,
+            lsp_context_used: lsp_enabled,
+            confidence: Map.get(result, :confidence, 0.0),
+            provider_metadata: Map.get(result, :metadata, %{})
+          }
 
-      {:error, reason} ->
+        {:error, reason} ->
+          %{
+            status: :error,
+            error: reason,
+            method: method,
+            lsp_context_used: lsp_enabled
+          }
+      end
+    rescue
+      ArgumentError ->
+        Logger.error("Security Warning: Attempted to convert non-existent atom from agent_module: #{inspect(agent_module)}")
         %{
           status: :error,
-          error: reason,
+          error: "Invalid provider module",
           method: method,
           lsp_context_used: lsp_enabled
         }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: User-controlled input (`agent_module`) was being converted to atoms dynamically using `String.to_atom/1` in `lib/lang/workers/lsp_comparison_worker.ex`.
🎯 Impact: An attacker or a malfunctioning agent could supply a large number of unique module names, which would continually generate new atoms. Because atoms are never garbage collected in the Erlang VM, this leads to atom table exhaustion and crashes the entire BEAM node, resulting in a Denial of Service.
🔧 Fix: Replaced `String.to_atom/1` with `String.to_existing_atom/1`. Added a `rescue` block to handle the `ArgumentError` correctly and return a secure fallback error map if the requested module atom does not exist. Also fixed an Elixir compiler warning by not binding the exception to an unused variable.
✅ Verification: The fix preserves correct behavior for existing, valid modules while returning a safe error map without creating new atoms for invalid module strings. Ensure `mix test` passes when the testing environment is fully available. Recorded learnings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15780605369872644791](https://jules.google.com/task/15780605369872644791) started by @locsic*