### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Remote Code Execution and DoS in agent task execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Do not use String.to_atom on user input
+**Vulnerability:** Converting untrusted input strings to atoms using `String.to_atom/1` can exhaust the BEAM atom table, leading to Denial of Service (DoS).
+**Learning:** `agent_module` is derived from an untrusted source (agent_variant["provider_module"]). Dynamic function dispatch (`apply/3`) using user input is also a critical Remote Code Execution (RCE) vector.
+**Prevention:** Always use `String.to_existing_atom/1` when converting strings to atoms if the string is expected to match a known entity. Furthermore, validate `agent_module` against an explicit allowlist before calling `apply/3`.

--- a/lib/lang/workers/lsp_comparison_worker.ex
+++ b/lib/lang/workers/lsp_comparison_worker.ex
@@ -261,22 +261,40 @@ defmodule Lang.Workers.LSPComparisonWorker do
     # Convert task to provider request format
     {method, params} = convert_task_to_provider_request(task, context, lsp_enabled)
 
-    # Execute via the agent variant
-    case apply(String.to_atom(agent_module), :handle_request, [method, params, []]) do
-      {:ok, result} ->
-        %{
-          status: :success,
-          output: result,
-          method: method,
-          lsp_context_used: lsp_enabled,
-          confidence: Map.get(result, :confidence, 0.0),
-          provider_metadata: Map.get(result, :metadata, %{})
-        }
+    # Execute via the agent variant safely preventing atom table exhaustion and RCE
+    try do
+      module_atom = String.to_existing_atom(agent_module)
 
-      {:error, reason} ->
+      # We cannot easily restrict to static allowed_modules because AgentVariantGenerator
+      # generates them dynamically. We can, however, verify the namespace or behaviour.
+      unless String.starts_with?(agent_module, "Elixir.Lang.Testing.Variants.") do
+        raise ArgumentError, "Invalid or unauthorized agent provider module specified"
+      end
+
+      case apply(module_atom, :handle_request, [method, params, []]) do
+        {:ok, result} ->
+          %{
+            status: :success,
+            output: result,
+            method: method,
+            lsp_context_used: lsp_enabled,
+            confidence: Map.get(result, :confidence, 0.0),
+            provider_metadata: Map.get(result, :metadata, %{})
+          }
+
+        {:error, reason} ->
+          %{
+            status: :error,
+            error: reason,
+            method: method,
+            lsp_context_used: lsp_enabled
+          }
+      end
+    rescue
+      ArgumentError ->
         %{
           status: :error,
-          error: reason,
+          error: "Invalid agent provider module specified",
           method: method,
           lsp_context_used: lsp_enabled
         }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsanitized user input `agent_variant["provider_module"]` was passed to `String.to_atom/1` (causing atom exhaustion DoS) and then dynamically dispatched using `apply/3` (introducing RCE potential).
🎯 **Impact:** An attacker could crash the node by exhausting the BEAM atom table, and execute arbitrary code by supplying a malicious module payload.
🔧 **Fix:** 
1. Replaced `String.to_atom/1` with `String.to_existing_atom/1` wrapped in a `try...rescue` block to handle invalid requests.
2. Implemented an explicit prefix check `String.starts_with?(agent_module, "Elixir.Lang.Testing.Variants.")` before executing `apply/3` to ensure that only expected provider variants are executed.
✅ **Verification:** A manual review of `lib/lang/workers/lsp_comparison_worker.ex` confirms that `apply/3` is protected by `String.to_existing_atom/1` and the necessary prefix allowlist.

---
*PR created automatically by Jules for task [14767808951994250462](https://jules.google.com/task/14767808951994250462) started by @locsic*