### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix RCE in LSPComparisonWorker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-10 - Unsafe Dynamic Module Dispatch in Agent Testing
+**Vulnerability:** Remote Code Execution (RCE) via `apply/3` with untrusted user input in `Lang.Workers.LSPComparisonWorker`. The `agent_variant["provider_module"]` string was directly converted to an atom and invoked.
+**Learning:** Elixir's `apply(module, function, args)` allows arbitrary function execution if the module name is controlled by an attacker. When dynamically calling generated agent modules under a specific namespace, we must strictly validate the namespace.
+**Prevention:** Always validate that dynamic module strings start with the expected prefix (e.g., `"Elixir.Lang.Testing.Variants."`) before converting to an atom and invoking `apply/3`.

--- a/lib/lang/workers/lsp_comparison_worker.ex
+++ b/lib/lang/workers/lsp_comparison_worker.ex
@@ -258,6 +258,11 @@ defmodule Lang.Workers.LSPComparisonWorker do
     # Reconstruct the agent module
     agent_module = agent_variant["provider_module"]
 
+    # Security check: Ensure module is within the safe Variants namespace to prevent RCE
+    unless String.starts_with?(agent_module, "Elixir.Lang.Testing.Variants.") do
+      raise ArgumentError, "Invalid agent variant module: #{agent_module}"
+    end
+
     # Convert task to provider request format
     {method, params} = convert_task_to_provider_request(task, context, lsp_enabled)
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Remote Code Execution (RCE) via `apply/3` with untrusted user input in `Lang.Workers.LSPComparisonWorker`.
🎯 Impact: Attackers could execute arbitrary code by manipulating the `provider_module` value in the `agent_variant` map, leading to full system compromise.
🔧 Fix: Add strict namespace validation. The string must start with `"Elixir.Lang.Testing.Variants."` before being converted to an atom and invoked.
✅ Verification: Review the code changes in `lib/lang/workers/lsp_comparison_worker.ex` and verify the unit test suite passes.

---
*PR created automatically by Jules for task [11037434603880297341](https://jules.google.com/task/11037434603880297341) started by @locsic*