### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Remote Code Execution in LSP Comparison Worker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Preventing Remote Code Execution via Dynamic Dispatch]
+**Vulnerability:** A critical Remote Code Execution (RCE) and DoS (Atom Exhaustion) vulnerability was found in `lib/lang/workers/lsp_comparison_worker.ex` due to the use of `apply(String.to_atom(agent_module), ...)` with dynamically generated untrusted input.
+**Learning:** The application dynamically dispatches tasks to testing variants. Directly casting strings to atoms and invoking them without validation allows attackers to execute arbitrary code or crash the BEAM VM.
+**Prevention:** Always validate the expected namespace prefix using `String.starts_with?` before dynamic module dispatch, and safely map to existing atoms using `String.to_existing_atom` wrapped in an isolated `try/rescue` block to handle invalid references.

--- a/lib/lang/workers/lsp_comparison_worker.ex
+++ b/lib/lang/workers/lsp_comparison_worker.ex
@@ -262,24 +262,44 @@ defmodule Lang.Workers.LSPComparisonWorker do
     {method, params} = convert_task_to_provider_request(task, context, lsp_enabled)
 
     # Execute via the agent variant
-    case apply(String.to_atom(agent_module), :handle_request, [method, params, []]) do
-      {:ok, result} ->
-        %{
-          status: :success,
-          output: result,
-          method: method,
-          lsp_context_used: lsp_enabled,
-          confidence: Map.get(result, :confidence, 0.0),
-          provider_metadata: Map.get(result, :metadata, %{})
-        }
+    if String.starts_with?(agent_module, "Elixir.Lang.Testing.Variants.") do
+      try do
+        module_atom = String.to_existing_atom(agent_module)
+        case apply(module_atom, :handle_request, [method, params, []]) do
+          {:ok, result} ->
+            %{
+              status: :success,
+              output: result,
+              method: method,
+              lsp_context_used: lsp_enabled,
+              confidence: Map.get(result, :confidence, 0.0),
+              provider_metadata: Map.get(result, :metadata, %{})
+            }
 
-      {:error, reason} ->
-        %{
-          status: :error,
-          error: reason,
-          method: method,
-          lsp_context_used: lsp_enabled
-        }
+          {:error, reason} ->
+            %{
+              status: :error,
+              error: reason,
+              method: method,
+              lsp_context_used: lsp_enabled
+            }
+        end
+      rescue
+        ArgumentError ->
+          %{
+            status: :error,
+            error: "Invalid agent variant module",
+            method: method,
+            lsp_context_used: lsp_enabled
+          }
+      end
+    else
+      %{
+        status: :error,
+        error: "Unauthorized agent module namespace",
+        method: method,
+        lsp_context_used: lsp_enabled
+      }
     end
   end
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Dynamic module dispatch (`apply/3`) using `String.to_atom/1` with unvalidated input.
🎯 Impact: This allowed attackers to cause Atom Exhaustion (DoS) by generating infinite atoms, and arbitrarily execute code via Remote Code Execution (RCE) by dispatching to unauthorized modules.
🔧 Fix: Used `String.starts_with?` to validate the `"Elixir.Lang.Testing.Variants."` namespace, and wrapped `String.to_existing_atom/1` in an isolated `try/rescue` block to handle nonexistent atom exceptions safely without crashing the BEAM VM.
✅ Verification: Code reviewed manually and confirmed by tests/review tool. Behavior appropriately returns standard mapped error structures when unauthorized or invalid variants are encountered.

---
*PR created automatically by Jules for task [5501487968308361004](https://jules.google.com/task/5501487968308361004) started by @locsic*