### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix RCE and Atom exhaustion in LSPComparisonWorker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - Fix RCE and Atom exhaustion vulnerabilities in LSPComparisonWorker
+**Vulnerability:** The code read an arbitrary string from user input (`agent_module`) and converted it to an atom via `String.to_atom`, leading to potential Atom Exhaustion (DoS). It also used the atom in `apply/3`, leading to a potential Remote Code Execution (RCE) vulnerability.
+**Learning:** We need to validate dynamic module dispatcher targets to prevent RCE.
+**Prevention:** Use `String.starts_with?/2` to validate the namespace of dynamically requested modules to ensure execution is safe, and use `String.to_existing_atom/1` in a `try/rescue` block to prevent atom exhaustion.

--- a/lib/lang/workers/lsp_comparison_worker.ex
+++ b/lib/lang/workers/lsp_comparison_worker.ex
@@ -258,11 +258,24 @@ defmodule Lang.Workers.LSPComparisonWorker do
     # Reconstruct the agent module
     agent_module = agent_variant["provider_module"]
 
+    # Validate agent_module prefix to prevent RCE
+    if not String.starts_with?(agent_module, "Elixir.Lang.Testing.Variants.") do
+      raise ArgumentError, "Invalid agent variant module: #{agent_module}"
+    end
+
+    module_atom =
+      try do
+        String.to_existing_atom(agent_module)
+      rescue
+        ArgumentError ->
+          raise ArgumentError, "Agent variant module not found: #{agent_module}"
+      end
+
     # Convert task to provider request format
     {method, params} = convert_task_to_provider_request(task, context, lsp_enabled)
 
     # Execute via the agent variant
-    case apply(String.to_atom(agent_module), :handle_request, [method, params, []]) do
+    case apply(module_atom, :handle_request, [method, params, []]) do
       {:ok, result} ->
         %{
           status: :success,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `LSPComparisonWorker` took an unsanitized module name (`agent_module`) string directly from the job arguments and invoked `String.to_atom/1` on it, making it vulnerable to Atom Exhaustion attacks. It then dynamically dispatched to this module using `apply/3` without verifying that the targeted module actually belonged to the proper namespace, leading to an Arbitrary Code Execution / Remote Code Execution (RCE) vulnerability.
🎯 Impact: An attacker could potentially run arbitrary code on the worker nodes (RCE) or easily crash the BEAM VM by continuously feeding new random string payloads, exhausting the finite atom space (DoS).
🔧 Fix: Updated `execute_agent_task/4` to validate that `agent_module` starts with the `Elixir.Lang.Testing.Variants.` prefix. Swapped `String.to_atom/1` for `String.to_existing_atom/1` executing safely inside a `try/rescue` block to handle `ArgumentError`.
✅ Verification: Tested manually. Ensure the background job fails elegantly if the `agent_module` does not match the expected whitelist prefix or does not already exist as an atom.

---
*PR created automatically by Jules for task [7441622080061059713](https://jules.google.com/task/7441622080061059713) started by @locsic*