### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix RCE and Atom exhaustion in dynamic module loading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Remote Code Execution via Untrusted Atom Creation
+**Vulnerability:** Found `apply(String.to_atom(agent_module), :handle_request, ...)` in `Lang.Workers.LSPComparisonWorker` executing dynamically provided untrusted input.
+**Learning:** `String.to_atom/1` with arbitrary input exposes the BEAM to Atom Exhaustion DOS and allows calling functions on any loaded module, enabling RCE.
+**Prevention:** Always use `String.to_existing_atom/1` for dynamically generated modules or validate the module string prefix securely (e.g., must start with `Elixir.Lang.Testing.Variants.`).

--- a/lib/lang/workers/lsp_comparison_worker.ex
+++ b/lib/lang/workers/lsp_comparison_worker.ex
@@ -261,25 +261,54 @@ defmodule Lang.Workers.LSPComparisonWorker do
     # Convert task to provider request format
     {method, params} = convert_task_to_provider_request(task, context, lsp_enabled)
 
-    # Execute via the agent variant
-    case apply(String.to_atom(agent_module), :handle_request, [method, params, []]) do
-      {:ok, result} ->
-        %{
-          status: :success,
-          output: result,
-          method: method,
-          lsp_context_used: lsp_enabled,
-          confidence: Map.get(result, :confidence, 0.0),
-          provider_metadata: Map.get(result, :metadata, %{})
-        }
+    # Validate the module namespace to prevent RCE
+    if String.starts_with?(agent_module, "Elixir.Lang.Testing.Variants.") do
+      # Isolate the try block to avoid masking ArgumentErrors from core logic
+      module_atom_result =
+        try do
+          {:ok, String.to_existing_atom(agent_module)}
+        rescue
+          ArgumentError -> {:error, "Module not found: #{agent_module}"}
+        end
 
-      {:error, reason} ->
-        %{
-          status: :error,
-          error: reason,
-          method: method,
-          lsp_context_used: lsp_enabled
-        }
+      case module_atom_result do
+        {:ok, module_atom} ->
+          # Execute via the agent variant
+          case apply(module_atom, :handle_request, [method, params, []]) do
+            {:ok, result} ->
+              %{
+                status: :success,
+                output: result,
+                method: method,
+                lsp_context_used: lsp_enabled,
+                confidence: Map.get(result, :confidence, 0.0),
+                provider_metadata: Map.get(result, :metadata, %{})
+              }
+
+            {:error, reason} ->
+              %{
+                status: :error,
+                error: reason,
+                method: method,
+                lsp_context_used: lsp_enabled
+              }
+          end
+
+        {:error, reason} ->
+          %{
+            status: :error,
+            error: reason,
+            method: method,
+            lsp_context_used: lsp_enabled
+          }
+      end
+    else
+      %{
+        status: :error,
+        error: "Invalid agent module namespace",
+        method: method,
+        lsp_context_used: lsp_enabled
+      }
     end
   end
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unrestricted use of `String.to_atom/1` with dynamically provided user input (`agent_module`) to execute an application layer via `apply/3`.
🎯 **Impact:** Exposes the application to an Atom Exhaustion Denial of Service (DoS) attack, as well as Remote Code Execution (RCE) by allowing execution of arbitrary functions on any currently loaded module (e.g., `System`, `File`).
🔧 **Fix:** Added validation to check that the module string begins with the expected `Elixir.Lang.Testing.Variants.` namespace prefix. Replaced `String.to_atom/1` with `String.to_existing_atom/1` inside a `try/rescue` block to ensure that only already-loaded and safely-prefixed agent modules are converted to atoms. If the prefix is invalid or the atom doesn't exist, it gracefully returns an error message matching the existing return structure.
✅ **Verification:** A code review confirmed the logic safely blocks untrusted modules and gracefully handles un-loaded modules with an `ArgumentError` capture. The fix has been verified via the pre-commit review.

---
*PR created automatically by Jules for task [14220439135814379213](https://jules.google.com/task/14220439135814379213) started by @locsic*