### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Atom Exhaustion (DoS) in Proxy Routing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-16 - Atom Exhaustion (DoS) via String.to_atom
+**Vulnerability:** The application used `String.to_atom/1` to parse service names and keys directly from external proxy requests.
+**Learning:** Because atoms are not garbage-collected in the BEAM VM, an attacker can supply random strings in proxy envelopes, exhausting the VM's atom table and causing a total system crash.
+**Prevention:** Always use `String.to_existing_atom/1` inside a try/rescue block when parsing user input into atoms. Fallback to an error tuple or keep the string format if the atom doesn't exist.

--- a/lib/lang/proxy/envelope.ex
+++ b/lib/lang/proxy/envelope.ex
@@ -65,7 +65,12 @@ defmodule Lang.Proxy.Envelope do
       "lsp" -> {:ok, :lsp}
       "mcp" -> {:ok, :mcp}
       "proxy" -> {:ok, :proxy}
-      other -> {:ok, String.to_atom(other)}
+      other ->
+        try do
+          {:ok, String.to_existing_atom(other)}
+        rescue
+          ArgumentError -> {:error, :invalid_service}
+        end
     end
   end
 

--- a/lib/lang/proxy/pipeline.ex
+++ b/lib/lang/proxy/pipeline.ex
@@ -81,7 +81,14 @@ defmodule Lang.Proxy.Pipeline do
   end
 
   defp normalize_service(s) when is_atom(s), do: s
-  defp normalize_service(s) when is_binary(s), do: String.to_atom(String.downcase(s))
+  defp normalize_service(s) when is_binary(s) do
+    s_downcase = String.downcase(s)
+    try do
+      String.to_existing_atom(s_downcase)
+    rescue
+      ArgumentError -> s_downcase
+    end
+  end
 
   defp prune(%{service: s, method: m, params: params}) do
     base = %{service: s, method: m}
@@ -99,7 +106,13 @@ defmodule Lang.Proxy.Pipeline do
   end
 
   defp normalize_key(k) when is_atom(k), do: k
-  defp normalize_key(k) when is_binary(k), do: String.to_atom(k)
+  defp normalize_key(k) when is_binary(k) do
+    try do
+      String.to_existing_atom(k)
+    rescue
+      ArgumentError -> k
+    end
+  end
 
   defp maybe_require_intent(env, assigns) do
     sensitive? = sensitive_op?(env)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Atom Exhaustion (Denial of Service). The proxy modules (`Lang.Proxy.Envelope` and `Lang.Proxy.Pipeline`) used `String.to_atom/1` on external user inputs to parse service names and keys. Because the BEAM VM does not garbage collect atoms, an attacker could supply arbitrary unique strings to the proxy endpoint to exhaust the VM's atom table, causing a full system crash.
🎯 Impact: Complete Denial of Service (DoS).
🔧 Fix: Replaced `String.to_atom/1` with `String.to_existing_atom/1` wrapped in a `try/rescue` block. `envelope.ex` now cleanly returns an `{:error, :invalid_service}` tuple when an invalid atom is provided. `pipeline.ex` safely falls back to returning the string representation instead of allocating a new atom.
✅ Verification: Code reviewed. Elixir tests were skipped because the test sandbox is missing the necessary `mix` and `mise` binaries as documented in memory.

---
*PR created automatically by Jules for task [11628683968044681163](https://jules.google.com/task/11628683968044681163) started by @locsic*